### PR TITLE
[NUT-1] Prefixer toutes les routes /api/v1/...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+.env

--- a/app/main.py
+++ b/app/main.py
@@ -9,4 +9,4 @@ app = FastAPI(
 )
 
 app.include_router(health.router)
-app.include_router(meal_analysis.router)
+app.include_router(meal_analysis.router, prefix="/api/v1")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.5
+pytest-asyncio==0.25.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,22 +5,27 @@ import types
 
 import sqlalchemy
 
-# Stubs charges avant l'import de app.main pour eviter les deps lourdes
-# (transformers, torch, PIL, psycopg2) dans les tests d'integration de routing.
+
+def _stub_transformers_pipeline(*_args, **_kwargs):
+    raise RuntimeError("transformers.pipeline stub : non utilisable en tests")
+
+
+def _stub_pil_image_open(*_args, **_kwargs):
+    raise RuntimeError("PIL.Image.open stub : non utilisable en tests")
+
+
 def _install_stubs() -> None:
+    """Stubs charges avant l'import de app.main pour eviter les deps lourdes
+    (transformers, torch, PIL, psycopg2) dans les tests d'integration de routing."""
     if "transformers" not in sys.modules:
         transformers = types.ModuleType("transformers")
-        transformers.pipeline = lambda *a, **k: (_ for _ in ()).throw(
-            RuntimeError("transformers.pipeline stub : non utilisable en tests")
-        )
+        transformers.pipeline = _stub_transformers_pipeline
         sys.modules["transformers"] = transformers
 
     if "PIL" not in sys.modules:
         pil = types.ModuleType("PIL")
         pil_image = types.ModuleType("PIL.Image")
-        pil_image.open = lambda *a, **k: (_ for _ in ()).throw(
-            RuntimeError("PIL.Image.open stub : non utilisable en tests")
-        )
+        pil_image.open = _stub_pil_image_open
         pil.Image = pil_image
         sys.modules["PIL"] = pil
         sys.modules["PIL.Image"] = pil_image
@@ -30,13 +35,16 @@ _install_stubs()
 
 
 # Force un engine SQLite en memoire pour les tests : evite la dep psycopg2
-# qui n'a pas de wheel pour Python 3.14.
+# qui n'a pas de wheel pour Python 3.14 (en local). On force l'import de
+# app.main sous patch puis on restaure create_engine pour eviter la fuite
+# globale du monkeypatch sur le reste du process de test.
 _real_create_engine = sqlalchemy.create_engine
 
 
-def _fake_create_engine(url, *args, **kwargs):
-    kwargs.pop("pool_pre_ping", None)
+def _fake_create_engine(_url, *_args, **_kwargs):
     return _real_create_engine("sqlite:///:memory:")
 
 
 sqlalchemy.create_engine = _fake_create_engine
+import app.main  # noqa: E402, F401  -- declenche la creation de l'engine sous patch
+sqlalchemy.create_engine = _real_create_engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import sqlalchemy
+
+# Stubs charges avant l'import de app.main pour eviter les deps lourdes
+# (transformers, torch, PIL, psycopg2) dans les tests d'integration de routing.
+def _install_stubs() -> None:
+    if "transformers" not in sys.modules:
+        transformers = types.ModuleType("transformers")
+        transformers.pipeline = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("transformers.pipeline stub : non utilisable en tests")
+        )
+        sys.modules["transformers"] = transformers
+
+    if "PIL" not in sys.modules:
+        pil = types.ModuleType("PIL")
+        pil_image = types.ModuleType("PIL.Image")
+        pil_image.open = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("PIL.Image.open stub : non utilisable en tests")
+        )
+        pil.Image = pil_image
+        sys.modules["PIL"] = pil
+        sys.modules["PIL.Image"] = pil_image
+
+
+_install_stubs()
+
+
+# Force un engine SQLite en memoire pour les tests : evite la dep psycopg2
+# qui n'a pas de wheel pour Python 3.14.
+_real_create_engine = sqlalchemy.create_engine
+
+
+def _fake_create_engine(url, *args, **kwargs):
+    kwargs.pop("pool_pre_ping", None)
+    return _real_create_engine("sqlite:///:memory:")
+
+
+sqlalchemy.create_engine = _fake_create_engine

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_stays_at_root():
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] in {"ok", "degraded"}
+
+
+def test_analyze_meal_no_prefix_returns_404():
+    response = client.post(
+        "/analyze-meal",
+        files={"photo": ("x.txt", b"hello", "text/plain")},
+        headers={"Authorization": "Bearer fake-token"},
+    )
+    assert response.status_code == 404
+
+
+def test_analyze_meal_v1_returns_415_for_bad_content_type():
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("x.txt", b"hello", "text/plain")},
+        headers={"Authorization": "Bearer fake-token"},
+    )
+    assert response.status_code == 415
+
+
+def test_openapi_lists_versioned_route():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert "/api/v1/analyze-meal" in paths
+    assert "/health" in paths
+    assert "/analyze-meal" not in paths


### PR DESCRIPTION
Closes #17

## Summary
- Prefixe le router metier (`POST /analyze-meal`) sous `/api/v1` pour aligner AI-Nutrition avec MSPR-AUTH (`/api/auth/*`) et MSPR-API (`/api/*`), et reserve `/api/v2` pour les evolutions futures.
- `GET /health` reste a la racine (convention orchestration : Docker healthcheck, Kubernetes probes).
- Ajoute 4 tests d'integration (sqlite + stubs `transformers`/`PIL`) couvrant : health 200, ancienne route 404, nouvelle route 415, OpenAPI liste `/api/v1/analyze-meal`.

## Test plan
- [ ] `pip install -r requirements-dev.txt && pytest tests/` passe (4 tests)
- [ ] Swagger UI sur `/docs` liste `POST /api/v1/analyze-meal`
- [ ] `curl -X POST http://localhost:8001/analyze-meal` renvoie 404
- [ ] `curl -X POST http://localhost:8001/api/v1/analyze-meal` repond a la requete