### PR TITLE
[NUT-4] CRUD GET/PUT /api/v1/nutrition-goals/me (avec health_goal)

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -45,3 +45,4 @@ class NutritionGoal(Base):
     fat_g = Column(Numeric(8, 2))
     allergies = Column(ARRAY(String))
     diet_type = Column(String(50))
+    health_goal = Column(String(30))

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from app.routers import health, meal_analysis
+from app.routers import health, meal_analysis, nutrition_goals
 
 app = FastAPI(
     title="MSPR HealthAI Coach — AI Nutrition",
@@ -10,3 +10,4 @@ app = FastAPI(
 
 app.include_router(health.router)
 app.include_router(meal_analysis.router, prefix="/api/v1")
+app.include_router(nutrition_goals.router, prefix="/api/v1")

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,7 +1,17 @@
+from __future__ import annotations
+
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 
 from pydantic import BaseModel
+
+
+class HealthGoal(str, Enum):
+    weight_loss = "weight_loss"
+    muscle_gain = "muscle_gain"
+    balance = "balance"
+    sport_performance = "sport_performance"
 
 
 # MealAnalysis
@@ -40,6 +50,7 @@ class MealPlanResponse(BaseModel):
 # NutritionGoal
 
 class NutritionGoalRequest(BaseModel):
+    health_goal: HealthGoal | None = None
     calories_target: int | None = None
     protein_g: Decimal | None = None
     carbs_g: Decimal | None = None

--- a/app/routers/nutrition_goals.py
+++ b/app/routers/nutrition_goals.py
@@ -16,8 +16,8 @@ def _user_id_from_auth(authorization: str | None) -> int:
     identity = jwt_decoder.decode(authorization.removeprefix("Bearer "))
     try:
         return int(identity.user_id)
-    except (TypeError, ValueError):
-        raise HTTPException(status_code=401, detail="Sujet JWT invalide.")
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
 
 
 @router.get("/me", response_model=NutritionGoalResponse)

--- a/app/routers/nutrition_goals.py
+++ b/app/routers/nutrition_goals.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.schemas import NutritionGoalRequest, NutritionGoalResponse
+from app.services import jwt_decoder, profile_service
+
+router = APIRouter(prefix="/nutrition-goals", tags=["nutrition-goals"])
+
+
+def _user_id_from_auth(authorization: str | None) -> int:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authorization header invalide.")
+    identity = jwt_decoder.decode(authorization.removeprefix("Bearer "))
+    try:
+        return int(identity.user_id)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Sujet JWT invalide.")
+
+
+@router.get("/me", response_model=NutritionGoalResponse)
+def get_my_profile(
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> NutritionGoalResponse:
+    user_id = _user_id_from_auth(authorization)
+    profile = profile_service.get_profile(user_id, db)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profil nutritionnel non configure.")
+    return NutritionGoalResponse.model_validate(profile)
+
+
+@router.put("/me", response_model=NutritionGoalResponse)
+def upsert_my_profile(
+    payload: NutritionGoalRequest,
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> NutritionGoalResponse:
+    user_id = _user_id_from_auth(authorization)
+    profile = profile_service.upsert_profile(user_id, payload, db)
+    return NutritionGoalResponse.model_validate(profile)

--- a/app/services/jwt_decoder.py
+++ b/app/services/jwt_decoder.py
@@ -25,6 +25,6 @@ def decode(token: str) -> UserIdentity:
             algorithms=["HS256"],
             options={"require": ["sub", "exp"]},
         )
-    except jwt.PyJWTError:
-        raise HTTPException(status_code=401, detail="Token invalide.")
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail="Token invalide.") from exc
     return UserIdentity(user_id=payload["sub"], email=payload.get("email"))

--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db.models import NutritionGoal
+from app.models.schemas import NutritionGoalRequest
+
+
+def get_profile(user_id: int, db: Session) -> NutritionGoal | None:
+    return db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).one_or_none()
+
+
+def upsert_profile(
+    user_id: int, payload: NutritionGoalRequest, db: Session
+) -> NutritionGoal:
+    profile = get_profile(user_id, db)
+    fields = payload.model_dump(exclude_unset=False)
+    if profile is None:
+        profile = NutritionGoal(user_id=user_id, **_normalize(fields))
+        db.add(profile)
+    else:
+        for key, value in _normalize(fields).items():
+            setattr(profile, key, value)
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def _normalize(fields: dict) -> dict:
+    # Pydantic serialise l'enum HealthGoal en str via model_dump(mode="python") par defaut,
+    # mais on stocke la valeur de l'enum (str) dans la colonne VARCHAR(30).
+    health_goal = fields.get("health_goal")
+    if health_goal is not None and hasattr(health_goal, "value"):
+        fields["health_goal"] = health_goal.value
+    return fields

--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -14,12 +14,12 @@ def upsert_profile(
     user_id: int, payload: NutritionGoalRequest, db: Session
 ) -> NutritionGoal:
     profile = get_profile(user_id, db)
-    fields = payload.model_dump(exclude_unset=False)
+    fields = _normalize(payload.model_dump())
     if profile is None:
-        profile = NutritionGoal(user_id=user_id, **_normalize(fields))
+        profile = NutritionGoal(user_id=user_id, **fields)
         db.add(profile)
     else:
-        for key, value in _normalize(fields).items():
+        for key, value in fields.items():
             setattr(profile, key, value)
     db.commit()
     db.refresh(profile)
@@ -31,5 +31,5 @@ def _normalize(fields: dict) -> dict:
     # mais on stocke la valeur de l'enum (str) dans la colonne VARCHAR(30).
     health_goal = fields.get("health_goal")
     if health_goal is not None and hasattr(health_goal, "value"):
-        fields["health_goal"] = health_goal.value
+        return {**fields, "health_goal": health_goal.value}
     return fields

--- a/tests/test_nutrition_goals_api.py
+++ b/tests/test_nutrition_goals_api.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Generator
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
+from jose import jwt
 from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.db.session import get_db
 from app.main import app
+from tests.conftest import TEST_AUTH_SECRET
 
 
 @pytest.fixture(autouse=True)
-def _set_secret(monkeypatch: pytest.MonkeyPatch, db_session: Session) -> None:
+def _set_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     """Aligne le secret JWT du service sur celui de la fixture valid_jwt."""
-    from tests.conftest import TEST_AUTH_SECRET
-
     monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
 
 
@@ -200,6 +201,38 @@ def test_invalid_jwt_returns_401(client: TestClient) -> None:
     response = client.get(
         "/api/v1/nutrition-goals/me",
         headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert response.status_code == 401
+
+
+def test_expired_jwt_returns_401(client: TestClient) -> None:
+    past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    expired = jwt.encode(
+        {"sub": "1", "iat": int(past.timestamp()), "exp": int(past.timestamp())},
+        TEST_AUTH_SECRET,
+        algorithm="HS256",
+    )
+    response = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": f"Bearer {expired}"},
+    )
+    assert response.status_code == 401
+
+
+def test_jwt_with_non_numeric_sub_returns_401(client: TestClient) -> None:
+    now = datetime.now(tz=timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": "uuid-not-an-int",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        TEST_AUTH_SECRET,
+        algorithm="HS256",
+    )
+    response = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 401
 

--- a/tests/test_nutrition_goals_api.py
+++ b/tests/test_nutrition_goals_api.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch: pytest.MonkeyPatch, db_session: Session) -> None:
+    """Aligne le secret JWT du service sur celui de la fixture valid_jwt."""
+    from tests.conftest import TEST_AUTH_SECRET
+
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+
+
+@pytest.fixture
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_put_creates_profile_and_returns_data(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=42)
+    payload = {
+        "health_goal": "muscle_gain",
+        "calories_target": 2400,
+        "protein_g": 180,
+        "carbs_g": 280,
+        "fat_g": 70,
+        "allergies": ["arachides"],
+        "diet_type": "omnivore",
+    }
+
+    response = client.put(
+        "/api/v1/nutrition-goals/me",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == 42
+    assert body["health_goal"] == "muscle_gain"
+    assert body["calories_target"] == 2400
+    assert body["allergies"] == ["arachides"]
+    assert body["diet_type"] == "omnivore"
+
+
+def test_get_returns_404_when_no_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=42)
+
+    response = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_returns_profile_after_put(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=7)
+    auth = {"Authorization": f"Bearer {token}"}
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "weight_loss", "calories_target": 1800, "diet_type": "vegetarien"},
+        headers=auth,
+    )
+
+    response = client.get("/api/v1/nutrition-goals/me", headers=auth)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == 7
+    assert body["health_goal"] == "weight_loss"
+    assert body["calories_target"] == 1800
+    assert body["diet_type"] == "vegetarien"
+
+
+def test_second_put_updates_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=12)
+    auth = {"Authorization": f"Bearer {token}"}
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "balance", "calories_target": 2000},
+        headers=auth,
+    )
+
+    response = client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "sport_performance", "calories_target": 2800},
+        headers=auth,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == 12
+    assert body["health_goal"] == "sport_performance"
+    assert body["calories_target"] == 2800
+
+    get_response = client.get("/api/v1/nutrition-goals/me", headers=auth)
+    assert get_response.json()["health_goal"] == "sport_performance"
+
+
+def test_put_with_invalid_health_goal_returns_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=42)
+
+    response = client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "marathon"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_user_cannot_read_another_users_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    alice_token = valid_jwt(user_id=100)
+    bob_token = valid_jwt(user_id=200)
+
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "muscle_gain", "calories_target": 3000},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    bob_get = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert bob_get.status_code == 404
+
+
+def test_user_cannot_overwrite_another_users_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    alice_token = valid_jwt(user_id=100)
+    bob_token = valid_jwt(user_id=200)
+
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "muscle_gain", "calories_target": 3000},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+    bob_put = client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "weight_loss", "calories_target": 1500},
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert bob_put.status_code == 200
+    assert bob_put.json()["user_id"] == 200
+
+    alice_get = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+    assert alice_get.status_code == 200
+    assert alice_get.json()["health_goal"] == "muscle_gain"
+    assert alice_get.json()["calories_target"] == 3000
+
+
+def test_missing_authorization_header_returns_401(client: TestClient) -> None:
+    get_resp = client.get("/api/v1/nutrition-goals/me")
+    put_resp = client.put("/api/v1/nutrition-goals/me", json={})
+    assert get_resp.status_code == 401
+    assert put_resp.status_code == 401
+
+
+def test_invalid_jwt_returns_401(client: TestClient) -> None:
+    response = client.get(
+        "/api/v1/nutrition-goals/me",
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert response.status_code == 401
+
+
+def test_put_accepts_all_health_goal_values(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    for idx, goal in enumerate(
+        ["weight_loss", "muscle_gain", "balance", "sport_performance"]
+    ):
+        token = valid_jwt(user_id=500 + idx)
+        response = client.put(
+            "/api/v1/nutrition-goals/me",
+            json={"health_goal": goal},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["health_goal"] == goal
+
+
+def test_put_with_minimal_payload_succeeds(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=42)
+
+    response = client.put(
+        "/api/v1/nutrition-goals/me",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == 42
+    assert body["health_goal"] is None
+    assert body["allergies"] == []

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -37,5 +37,7 @@ def test_openapi_lists_versioned_route():
     assert response.status_code == 200
     paths = response.json()["paths"]
     assert "/api/v1/analyze-meal" in paths
+    assert "/api/v1/nutrition-goals/me" in paths
     assert "/health" in paths
     assert "/analyze-meal" not in paths
+    assert "/nutrition-goals/me" not in paths


### PR DESCRIPTION
Closes #24

## Summary

Implemente le CRUD du profil nutritionnel de l'utilisateur courant, expose sous `/api/v1/nutrition-goals/me` :

- `GET /api/v1/nutrition-goals/me` : retourne le profil de l'user authentifie (ou 404 si pas encore configure).
- `PUT /api/v1/nutrition-goals/me` : upsert (cree ou met a jour) le profil.

Le `user_id` vient toujours du JWT (`sub`), jamais d'un parametre client.

Modeles enrichis :
- SQLAlchemy `NutritionGoal` : ajout `health_goal = Column(String(30))`.
- Pydantic `NutritionGoalRequest` : ajout `health_goal: HealthGoal | None = None`.
- Enum `HealthGoal` : `weight_loss`, `muscle_gain`, `balance`, `sport_performance` (validation 422 sur valeur hors enum).

Module `services/profile_service.py` interface :
```python
def get_profile(user_id: int, db: Session) -> NutritionGoal | None
def upsert_profile(user_id: int, payload: NutritionGoalRequest, db: Session) -> NutritionGoal
```

11 tests d'integration ajoutes (38 tests au total, 0 regression).

## Test plan

- [ ] `docker compose --profile test run --rm tests pytest -m "not slow"` -> 38 passed
- [ ] Verifier qu'un PUT genere bien une ligne dans `nutrition_goals` (PG check)
- [ ] Verifier qu'un GET avec un JWT signe par MSPR-AUTH retourne le bon profil
- [ ] Verifier qu'un user A ne peut pas lire/modifier le profil de user B
- [ ] Verifier que `health_goal: "marathon"` retourne bien 422

## Blocked by (deja merges)

- #16 (NUT-2 : jwt_decoder) — OK, commit 7cfbff2
- #18 (NUT-3 : modeles SQLAlchemy nettoyes) — OK, commit 079a833
- whitefoxxyt/MSPR-HealthAI-Coach-BDD#1 (DB-1 : V9 health_goal) — OK