### PR TITLE
[NUT-10] Matrice 16 templates de recommandations (imbalance x health_goal)

### DIFF
--- a/app/data/recommendations_matrix.py
+++ b/app/data/recommendations_matrix.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Imbalance(str, Enum):
+    HIGH_CALORIES = "HIGH_CALORIES"
+    LOW_PROTEIN = "LOW_PROTEIN"
+    HIGH_CARBS = "HIGH_CARBS"
+    HIGH_FAT = "HIGH_FAT"
+
+
+class HealthGoal(str, Enum):
+    WEIGHT_LOSS = "weight_loss"
+    MUSCLE_GAIN = "muscle_gain"
+    BALANCE = "balance"
+    SPORT_PERFORMANCE = "sport_performance"
+
+
+RECOMMENDATIONS_MATRIX: dict[tuple[Imbalance, HealthGoal], str] = {
+    (Imbalance.HIGH_CALORIES, HealthGoal.WEIGHT_LOSS): (
+        "Repas trop riche pour ton objectif de perte de poids. Reduis les "
+        "portions et privilegie des aliments rassasiants comme les legumes "
+        "verts ou les proteines maigres."
+    ),
+    (Imbalance.HIGH_CALORIES, HealthGoal.MUSCLE_GAIN): (
+        "Bonne densite calorique pour soutenir ta prise de masse. Verifie "
+        "tout de meme que l'apport en proteines suit (1.6 a 2g/kg/jour)."
+    ),
+    (Imbalance.HIGH_CALORIES, HealthGoal.BALANCE): (
+        "Repas tres calorique. Pour garder ta journee equilibree, allege "
+        "le repas suivant et ajoute davantage de legumes au prochain plat."
+    ),
+    (Imbalance.HIGH_CALORIES, HealthGoal.SPORT_PERFORMANCE): (
+        "Repas dense en calories : ideal en pre-entrainement, allege le "
+        "repas qui suit la seance."
+    ),
+    (Imbalance.LOW_PROTEIN, HealthGoal.WEIGHT_LOSS): (
+        "Apport en proteines insuffisant. Pour preserver ta masse maigre "
+        "pendant ta perte de poids, ajoute du poulet, du poisson ou des "
+        "oeufs au prochain repas."
+    ),
+    (Imbalance.LOW_PROTEIN, HealthGoal.MUSCLE_GAIN): (
+        "Pour ta prise de masse, ajoute une portion de poulet, oeufs ou "
+        "legumineuses au prochain repas (objectif : 2g/kg/jour)."
+    ),
+    (Imbalance.LOW_PROTEIN, HealthGoal.BALANCE): (
+        "Pense a renforcer l'apport en proteines au prochain repas avec du "
+        "poisson, des legumineuses ou des produits laitiers."
+    ),
+    (Imbalance.LOW_PROTEIN, HealthGoal.SPORT_PERFORMANCE): (
+        "Pas assez de proteines pour soutenir ta performance sportive. Vise "
+        "1.6 a 2g/kg/jour en repartissant sur 3 a 4 repas (poulet, oeufs, whey)."
+    ),
+    (Imbalance.HIGH_CARBS, HealthGoal.WEIGHT_LOSS): (
+        "Pour ton objectif de perte de poids, remplace les sucres rapides "
+        "par des legumes verts ou des cereales completes."
+    ),
+    (Imbalance.HIGH_CARBS, HealthGoal.MUSCLE_GAIN): (
+        "Bonne base de glucides pour ta prise de masse. Verifie que les "
+        "proteines suivent (1.6 a 2g/kg/jour) et hydrate-toi correctement."
+    ),
+    (Imbalance.HIGH_CARBS, HealthGoal.BALANCE): (
+        "Repas riche en glucides. Pour un meilleur equilibre, ajoute des "
+        "legumes verts et privilegie les cereales completes au prochain repas."
+    ),
+    (Imbalance.HIGH_CARBS, HealthGoal.SPORT_PERFORMANCE): (
+        "Apport eleve en glucides : parfait pour recharger tes reserves "
+        "avant ou apres l'entrainement. Pense a accompagner d'une source "
+        "de proteines."
+    ),
+    (Imbalance.HIGH_FAT, HealthGoal.WEIGHT_LOSS): (
+        "Repas riche en graisses, peu compatible avec ta perte de poids. "
+        "Reduis les fritures et les sauces, privilegie la cuisson vapeur "
+        "ou au four."
+    ),
+    (Imbalance.HIGH_FAT, HealthGoal.MUSCLE_GAIN): (
+        "Densite calorique elevee utile pour ta prise de masse, mais "
+        "surveille la qualite des graisses : favorise les bonnes (avocat, "
+        "huile d'olive, poissons gras)."
+    ),
+    (Imbalance.HIGH_FAT, HealthGoal.BALANCE): (
+        "Repas trop gras pour rester equilibre. Allege le repas suivant et "
+        "privilegie des cuissons plus simples (vapeur, four, grille)."
+    ),
+    (Imbalance.HIGH_FAT, HealthGoal.SPORT_PERFORMANCE): (
+        "Repas riche en graisses : evite-le juste avant l'entrainement "
+        "(digestion lente). Garde-le pour les repas eloignes des seances."
+    ),
+}
+
+GENERIC_FALLBACK = (
+    "Pense a equilibrer ton prochain repas pour rester aligne avec tes "
+    "objectifs nutritionnels."
+)
+
+
+def get_recommendation(
+    imbalance: Imbalance, health_goal: HealthGoal | None
+) -> str:
+    if health_goal is None:
+        return GENERIC_FALLBACK
+    return RECOMMENDATIONS_MATRIX.get(
+        (imbalance, health_goal), GENERIC_FALLBACK
+    )

--- a/tests/unit/test_recommendations_matrix.py
+++ b/tests/unit/test_recommendations_matrix.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from app.data.recommendations_matrix import (
+    GENERIC_FALLBACK,
+    RECOMMENDATIONS_MATRIX,
+    HealthGoal,
+    Imbalance,
+    get_recommendation,
+)
+
+
+def test_returns_specific_phrase_for_low_protein_muscle_gain() -> None:
+    phrase = get_recommendation(Imbalance.LOW_PROTEIN, HealthGoal.MUSCLE_GAIN)
+    assert "prise de masse" in phrase.lower() or "proteine" in phrase.lower()
+    assert len(phrase) > 0
+
+
+def test_returns_generic_fallback_when_health_goal_is_none() -> None:
+    phrase = get_recommendation(Imbalance.LOW_PROTEIN, None)
+    assert phrase == GENERIC_FALLBACK
+
+
+def test_matrix_has_all_16_combinations() -> None:
+    expected_keys = {
+        (imbalance, health_goal)
+        for imbalance in Imbalance
+        for health_goal in HealthGoal
+    }
+    assert set(RECOMMENDATIONS_MATRIX.keys()) == expected_keys
+    assert len(RECOMMENDATIONS_MATRIX) == 16
+
+
+@pytest.mark.parametrize("imbalance", list(Imbalance))
+@pytest.mark.parametrize("health_goal", list(HealthGoal))
+def test_each_combination_returns_non_empty_specific_phrase(
+    imbalance: Imbalance, health_goal: HealthGoal
+) -> None:
+    phrase = get_recommendation(imbalance, health_goal)
+    assert phrase != GENERIC_FALLBACK
+    assert len(phrase) >= 20
+
+
+def test_no_em_dashes_in_any_phrase() -> None:
+    forbidden = ["—", "–"]
+    offenders = [
+        (key, phrase)
+        for key, phrase in RECOMMENDATIONS_MATRIX.items()
+        for char in forbidden
+        if char in phrase
+    ]
+    assert offenders == [], f"phrases contiennent des tirets cadratins : {offenders}"
+    for char in forbidden:
+        assert char not in GENERIC_FALLBACK


### PR DESCRIPTION
Closes #20

## Summary
Ajoute `app/data/recommendations_matrix.py` avec les enums `Imbalance` (4) et `HealthGoal` (4), un dict `RECOMMENDATIONS_MATRIX` couvrant les 16 couples, un helper `get_recommendation(imbalance, health_goal | None) -> str` et un `GENERIC_FALLBACK` retourne quand `health_goal` est `None` ou inconnu. Sert de fallback texte pour `POST /api/v1/analyze-meal` quand l'appel LLM (NUT-7) echoue.

## Test plan
- [x] `pytest tests/unit/test_recommendations_matrix.py` : 20 tests verts (specifique LOW_PROTEIN/MUSCLE_GAIN, fallback `None`, completude des 16 cles, parametrise 16x non-vide, garde anti tirets cadratins)
- [x] `pytest tests/unit/` complet : 39 verts, pas de regression
- [x] `ruff check` propre sur les fichiers ajoutes
- [ ] Verifier la lecture des 16 phrases (ton coach, tutoiement, 2-3 phrases) en review