### PR TITLE
[NUT-5] entitlements_client (httpx + cache TTL 60s + degrade safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ DB_USER=healthai_user
 DB_PASSWORD=password
 OLLAMA_HOST=http://ollama:11434
 BETTER_AUTH_SECRET=change-me-shared-with-mspr-auth
+AUTH_API_URL=http://mspr-healthai-auth:3000

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     db_password: str = "password"
     ollama_host: str = "http://ollama:11434"
     better_auth_secret: str = ""
+    auth_api_url: str = "http://mspr-healthai-auth:3000"
 
     @property
     def database_url(self) -> str:

--- a/app/services/entitlements_client.py
+++ b/app/services/entitlements_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Literal, get_args
 
 import httpx
 from cachetools import TTLCache
@@ -17,23 +17,28 @@ Tier = Literal["free", "premium", "premium_plus"]
 _TIMEOUT_S = 3.0
 _CACHE_TTL_S = 60.0
 _CACHE_MAXSIZE = 10000
+# Le stale conserve la derniere valeur connue bien plus longtemps que le cache vif
+# pour rester utile en cas d'indisponibilite prolongee de MSPR-AUTH, mais reste
+# borne pour eviter la fuite memoire si le service voit beaucoup d'user_ids distincts.
+_STALE_TTL_S = 24 * 60 * 60.0
+_STALE_MAXSIZE = 10000
 
 
-@dataclass
+@dataclass(frozen=True)
 class Entitlements:
     tier: Tier
     expires_at: datetime | None
-    features: list[str]
+    features: tuple[str, ...]
 
 
 # Cache TTL in-memory : 60s par user_id, plafonne pour eviter une fuite memoire.
 _cache: TTLCache[str, Entitlements] = TTLCache(maxsize=_CACHE_MAXSIZE, ttl=_CACHE_TTL_S)
 # Dernier resultat connu par user_id, conserve meme apres expiration du cache TTL,
 # pour servir de fallback degrade quand MSPR-AUTH timeout ou est injoignable.
-_stale: dict[str, Entitlements] = {}
+_stale: TTLCache[str, Entitlements] = TTLCache(maxsize=_STALE_MAXSIZE, ttl=_STALE_TTL_S)
 
-_FREE = Entitlements(tier="free", expires_at=None, features=[])
-_VALID_TIERS = {"free", "premium", "premium_plus"}
+_FREE = Entitlements(tier="free", expires_at=None, features=())
+_VALID_TIERS = set(get_args(Tier))
 
 
 def _parse(payload: dict) -> Entitlements:
@@ -45,7 +50,7 @@ def _parse(payload: dict) -> Entitlements:
     features = payload.get("features") or []
     if not isinstance(features, list):
         raise ValueError("features doit etre une liste")
-    return Entitlements(tier=tier, expires_at=expires_at, features=list(features))
+    return Entitlements(tier=tier, expires_at=expires_at, features=tuple(features))
 
 
 async def get_entitlements(user_id: str, jwt: str) -> Entitlements:

--- a/app/services/entitlements_client.py
+++ b/app/services/entitlements_client.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+import httpx
+from cachetools import TTLCache
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+Tier = Literal["free", "premium", "premium_plus"]
+
+_TIMEOUT_S = 3.0
+_CACHE_TTL_S = 60.0
+_CACHE_MAXSIZE = 10000
+
+
+@dataclass
+class Entitlements:
+    tier: Tier
+    expires_at: datetime | None
+    features: list[str]
+
+
+# Cache TTL in-memory : 60s par user_id, plafonne pour eviter une fuite memoire.
+_cache: TTLCache[str, Entitlements] = TTLCache(maxsize=_CACHE_MAXSIZE, ttl=_CACHE_TTL_S)
+# Dernier resultat connu par user_id, conserve meme apres expiration du cache TTL,
+# pour servir de fallback degrade quand MSPR-AUTH timeout ou est injoignable.
+_stale: dict[str, Entitlements] = {}
+
+_FREE = Entitlements(tier="free", expires_at=None, features=[])
+_VALID_TIERS = {"free", "premium", "premium_plus"}
+
+
+def _parse(payload: dict) -> Entitlements:
+    tier = payload.get("tier")
+    if tier not in _VALID_TIERS:
+        raise ValueError(f"tier invalide: {tier!r}")
+    raw_exp = payload.get("expires_at")
+    expires_at = datetime.fromisoformat(raw_exp) if raw_exp else None
+    features = payload.get("features") or []
+    if not isinstance(features, list):
+        raise ValueError("features doit etre une liste")
+    return Entitlements(tier=tier, expires_at=expires_at, features=list(features))
+
+
+async def get_entitlements(user_id: str, jwt: str) -> Entitlements:
+    cached = _cache.get(user_id)
+    if cached is not None:
+        return cached
+
+    url = f"{settings.auth_api_url.rstrip('/')}/api/entitlements/me"
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(url, headers=headers)
+    except httpx.RequestError as exc:
+        logger.warning(
+            "entitlements: erreur reseau MSPR-AUTH (%s), degrade pour user_id=%s",
+            exc,
+            user_id,
+        )
+        return _stale.get(user_id, _FREE)
+
+    if response.status_code >= 400:
+        logger.warning(
+            "entitlements: status %d de MSPR-AUTH, degrade vers free pour user_id=%s",
+            response.status_code,
+            user_id,
+        )
+        return _FREE
+
+    try:
+        ent = _parse(response.json())
+    except (ValueError, TypeError) as exc:
+        logger.warning(
+            "entitlements: reponse invalide de MSPR-AUTH (%s), degrade vers free pour user_id=%s",
+            exc,
+            user_id,
+        )
+        return _FREE
+
+    _cache[user_id] = ent
+    _stale[user_id] = ent
+    return ent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - .env
     environment:
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+      - AUTH_API_URL=${AUTH_API_URL:-http://mspr-healthai-auth:3000}
     depends_on:
       - ollama
     networks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 pytest-asyncio==0.25.0
 pytest-cov==6.0.0
-respx==0.21.1
+respx==0.22.0
 testcontainers[postgresql]==4.9.0
 python-jose[cryptography]==3.3.0
 ruff==0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pydantic-settings==2.8.1
 transformers==4.51.3
 torch==2.7.0+cpu
 pyjwt==2.10.1
+cachetools==5.5.0
 pytest==8.3.4

--- a/tests/unit/test_entitlements_client.py
+++ b/tests/unit/test_entitlements_client.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import respx
+from cachetools import TTLCache
+
+from app.config import settings
+from app.services import entitlements_client
+from app.services.entitlements_client import Entitlements, get_entitlements
+
+AUTH_URL = "http://mspr-healthai-auth-test:3000"
+ENDPOINT = f"{AUTH_URL}/api/entitlements/me"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "auth_api_url", AUTH_URL)
+    entitlements_client._cache.clear()
+    entitlements_client._stale.clear()
+
+
+async def test_returns_tier_free_when_auth_responds_with_free() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(
+            200,
+            json={"tier": "free", "expires_at": None, "features": []},
+        )
+
+        result = await get_entitlements(user_id="u-1", jwt="jwt-token")
+
+    assert isinstance(result, Entitlements)
+    assert result.tier == "free"
+    assert result.expires_at is None
+    assert result.features == []
+
+
+async def test_second_call_with_same_user_id_hits_cache() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(ENDPOINT).respond(
+            200,
+            json={"tier": "premium", "expires_at": None, "features": []},
+        )
+
+        first = await get_entitlements(user_id="u-cache", jwt="jwt-token")
+        second = await get_entitlements(user_id="u-cache", jwt="jwt-token")
+
+    assert route.call_count == 1
+    assert first.tier == "premium"
+    assert second.tier == "premium"
+
+
+async def test_cache_expires_after_ttl_and_refetches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Horloge pilotee : permet de simuler le passage de plus de 60s sans dormir.
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        entitlements_client,
+        "_cache",
+        TTLCache(maxsize=10000, ttl=60.0, timer=lambda: clock["now"]),
+    )
+
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(ENDPOINT).respond(
+            200,
+            json={"tier": "free", "expires_at": None, "features": []},
+        )
+
+        await get_entitlements(user_id="u-ttl", jwt="jwt-token")
+        clock["now"] += 61.0
+        await get_entitlements(user_id="u-ttl", jwt="jwt-token")
+
+    assert route.call_count == 2
+
+
+async def test_timeout_without_prior_cache_degrades_to_free() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).mock(side_effect=httpx.ConnectTimeout("auth down"))
+
+        result = await get_entitlements(user_id="u-timeout", jwt="jwt-token")
+
+    assert result.tier == "free"
+    assert result.expires_at is None
+    assert result.features == []
+
+
+async def test_timeout_returns_stale_cache_when_available() -> None:
+    # Premier appel : MSPR-AUTH repond, on remplit le cache et le stale.
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(
+            200,
+            json={"tier": "premium_plus", "expires_at": None, "features": ["a"]},
+        )
+        await get_entitlements(user_id="u-stale", jwt="jwt-token")
+
+    # Le TTL expire (purge du cache vif), mais _stale conserve la valeur.
+    entitlements_client._cache.clear()
+
+    # Second appel : MSPR-AUTH timeout, on doit retomber sur la valeur stale.
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).mock(side_effect=httpx.ReadTimeout("auth slow"))
+
+        result = await get_entitlements(user_id="u-stale", jwt="jwt-token")
+
+    assert result.tier == "premium_plus"
+    assert result.features == ["a"]
+
+
+async def test_unknown_tier_value_degrades_to_free() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(
+            200,
+            json={"tier": "diamond", "expires_at": None, "features": []},
+        )
+
+        result = await get_entitlements(user_id="u-bad-tier", jwt="jwt-token")
+
+    assert result.tier == "free"
+
+
+async def test_invalid_json_payload_degrades_to_free() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(200, text="<html>not json</html>")
+
+        result = await get_entitlements(user_id="u-html", jwt="jwt-token")
+
+    assert result.tier == "free"
+
+
+async def test_missing_tier_field_degrades_to_free() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(200, json={"expires_at": None, "features": []})
+
+        result = await get_entitlements(user_id="u-no-tier", jwt="jwt-token")
+
+    assert result.tier == "free"
+
+
+async def test_401_from_auth_degrades_to_free_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(401, json={"error": "unauthorized"})
+
+        with caplog.at_level("WARNING", logger="app.services.entitlements_client"):
+            result = await get_entitlements(user_id="alice", jwt="bad-jwt")
+
+    assert result.tier == "free"
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "401" in r.getMessage() for r in warnings
+    ), f"aucun warning ne mentionne 401: {[r.getMessage() for r in warnings]}"
+
+
+async def test_500_from_auth_degrades_without_caching() -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(500, json={"error": "boom"})
+
+        result = await get_entitlements(user_id="u-500", jwt="jwt-token")
+
+    assert result.tier == "free"
+    # Le 5xx ne doit pas etre persiste : un appel ulterieur doit retenter MSPR-AUTH.
+    assert "u-500" not in entitlements_client._cache
+
+
+async def test_returns_tier_premium_with_features_and_expiry() -> None:
+    expires_iso = "2026-12-31T23:59:59+00:00"
+    with respx.mock(assert_all_called=True) as router:
+        router.get(ENDPOINT).respond(
+            200,
+            json={
+                "tier": "premium",
+                "expires_at": expires_iso,
+                "features": ["meal_plans_unlimited", "no_cache"],
+            },
+        )
+
+        result = await get_entitlements(user_id="u-2", jwt="jwt-token")
+
+    assert result.tier == "premium"
+    assert result.expires_at == datetime(2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    assert result.features == ["meal_plans_unlimited", "no_cache"]

--- a/tests/unit/test_entitlements_client.py
+++ b/tests/unit/test_entitlements_client.py
@@ -34,7 +34,7 @@ async def test_returns_tier_free_when_auth_responds_with_free() -> None:
     assert isinstance(result, Entitlements)
     assert result.tier == "free"
     assert result.expires_at is None
-    assert result.features == []
+    assert result.features == ()
 
 
 async def test_second_call_with_same_user_id_hits_cache() -> None:
@@ -84,7 +84,7 @@ async def test_timeout_without_prior_cache_degrades_to_free() -> None:
 
     assert result.tier == "free"
     assert result.expires_at is None
-    assert result.features == []
+    assert result.features == ()
 
 
 async def test_timeout_returns_stale_cache_when_available() -> None:
@@ -106,7 +106,7 @@ async def test_timeout_returns_stale_cache_when_available() -> None:
         result = await get_entitlements(user_id="u-stale", jwt="jwt-token")
 
     assert result.tier == "premium_plus"
-    assert result.features == ["a"]
+    assert result.features == ("a",)
 
 
 async def test_unknown_tier_value_degrades_to_free() -> None:
@@ -182,4 +182,4 @@ async def test_returns_tier_premium_with_features_and_expiry() -> None:
 
     assert result.tier == "premium"
     assert result.expires_at == datetime(2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
-    assert result.features == ["meal_plans_unlimited", "no_cache"]
+    assert result.features == ("meal_plans_unlimited", "no_cache")


### PR DESCRIPTION
Closes #25

## Summary

`app/services/entitlements_client.get_entitlements(user_id, jwt)` interroge `GET /api/entitlements/me` sur MSPR-AUTH (httpx, timeout 3s) avec un cache `cachetools.TTLCache` (60s, maxsize 10000) par `user_id`. Comportement degrade safe : timeout/erreur reseau retombe sur le dernier resultat connu (stale cache) puis sur `tier=free` ; reponse 4xx/5xx ou JSON malforme retombe directement sur `tier=free` avec un warning log. Variable d'env `AUTH_API_URL` ajoutee a `app/config.py`, `.env.example` et `docker-compose.yml`. Dependance `cachetools` ajoutee a `requirements.txt`.

`respx` est passe de 0.21.1 a 0.22.0 dans `requirements-dev.txt` : la 0.21.1 n'intercepte plus rien avec httpx 0.28 (les tests existants ne sollicitaient pas respx, la regression etait latente).

## Test plan

- [x] `pytest tests/unit/test_entitlements_client.py` (11 tests verts) couvre : tier=free, tier=premium avec expires_at + features, cache hit (1 seul appel HTTP), TTL expiry (refetch via timer pilote), timeout sans cache -> free, timeout avec cache -> stale, tier inconnu -> free, JSON invalide -> free, champ tier manquant -> free, 401 -> free + warning mentionnant "401", 500 -> free sans caching.
- [ ] Verifier en stack docker complete (`docker compose up`) que la lecture de `AUTH_API_URL` resout bien vers `mspr-healthai-auth:3000` une fois AUTH-2 (`/api/entitlements/me`) merge cote MSPR-AUTH.
- [ ] Lance `pytest -m "not slow"` en CI quand la PR pointera sur `master` (la cible actuelle est `feat/nut-api-phases-4-6`).