### PR TITLE
[NUT-11] Integration LLM dans /analyze-meal pour recommandations + fallback matrice

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -21,6 +21,10 @@ class MealAnalysis(Base):
     detected_foods = Column(JSONB, nullable=False, server_default=text("'[]'"))
     macros = Column(JSONB, nullable=False, server_default=text("'{}'"))
     confidence_scores = Column(JSONB, nullable=False, server_default=text("'{}'"))
+    # Recommandations textuelles : LLM Ollama avec fallback matrice statique (V9).
+    recommendations = Column(JSONB, nullable=False, server_default=text("'[]'"))
+    # Cle de cache (top_food_label, health_goal, imbalances). 30 jours TTL (V10).
+    recommendations_hash = Column(String(64))
     created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
 

--- a/app/routers/meal_analysis.py
+++ b/app/routers/meal_analysis.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-import asyncio
-
 from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile
 from sqlalchemy.orm import Session
 
-from app.db.models import MealAnalysis, NutritionGoal
 from app.db.session import get_db
 from app.services import jwt_decoder
-from app.services.food_classifier import classify_image
-from app.services.nutrition_lookup import lookup_nutrition
+from app.services.meal_analysis_orchestrator import analyze_meal as orchestrate
 
 router = APIRouter()
 
@@ -17,131 +13,30 @@ _MAX_SIZE = 10 * 1024 * 1024  # 10 Mo
 _ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+def _user_id_from_auth(authorization: str | None) -> int:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authorization header invalide.")
+    identity = jwt_decoder.decode(authorization.removeprefix("Bearer "))
+    try:
+        return int(identity.user_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
 
-def _detect_imbalances(macros: dict, goal: NutritionGoal | None) -> list[str]:
-    if goal is None or not macros:
-        return []
-    issues = []
-    if goal.calories_target and macros.get("calories"):
-        ratio = macros["calories"] / float(goal.calories_target)
-        if ratio > 0.6:
-            issues.append(
-                f"Apport calorique élevé : {macros['calories']:.0f} kcal "
-                f"({ratio:.0%} de l'objectif journalier de {goal.calories_target} kcal)"
-            )
-    if goal.protein_g and macros.get("protein_g") is not None:
-        if macros["protein_g"] < float(goal.protein_g) * 0.2:
-            issues.append(
-                f"Faible en protéines : {macros['protein_g']:.1f}g "
-                f"(objectif journalier : {goal.protein_g}g)"
-            )
-    if goal.carbs_g and macros.get("carbs_g") is not None:
-        if macros["carbs_g"] > float(goal.carbs_g) * 0.7:
-            issues.append(
-                f"Élevé en glucides : {macros['carbs_g']:.1f}g "
-                f"(objectif journalier : {goal.carbs_g}g)"
-            )
-    if goal.fat_g and macros.get("fat_g") is not None:
-        if macros["fat_g"] > float(goal.fat_g) * 0.7:
-            issues.append(
-                f"Élevé en lipides : {macros['fat_g']:.1f}g "
-                f"(objectif journalier : {goal.fat_g}g)"
-            )
-    return issues
-
-
-def _build_recommendations(imbalances: list[str]) -> list[str]:
-    if not imbalances:
-        return ["Repas équilibré par rapport à vos objectifs nutritionnels."]
-    recs = []
-    for msg in imbalances:
-        if "protéines" in msg:
-            recs.append("Ajoutez une source de protéines (poulet, légumineuses, œufs).")
-        elif "glucides" in msg:
-            recs.append("Réduisez les glucides rapides et préférez les céréales complètes.")
-        elif "lipides" in msg:
-            recs.append("Limitez les graisses saturées ; privilégiez avocat, noix, huile d'olive.")
-        elif "calorique" in msg:
-            recs.append("Repas dense en calories : allégez les autres repas de la journée.")
-    return recs or ["Consultez un nutritionniste pour des recommandations personnalisées."]
-
-
-# ---------------------------------------------------------------------------
-# Endpoint
-# ---------------------------------------------------------------------------
 
 @router.post("/analyze-meal")
 async def analyze_meal(
     photo: UploadFile = File(...),
-    authorization: str = Header(...),
+    authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ):
-    # --- Validation de l'image ---
     if photo.content_type not in _ALLOWED_TYPES:
         raise HTTPException(
             status_code=415,
-            detail=f"Type non supporté : {photo.content_type}. Utilisez JPEG, PNG ou WebP.",
+            detail=f"Type non supporte : {photo.content_type}. Utilisez JPEG, PNG ou WebP.",
         )
     image_bytes = await photo.read()
     if len(image_bytes) > _MAX_SIZE:
         raise HTTPException(status_code=413, detail="Image trop volumineuse (max 10 Mo).")
 
-    # --- Extraction du JWT ---
-    if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Authorization header invalide.")
-    jwt_token = authorization.removeprefix("Bearer ")
-
-    # --- Identite utilisateur (decode local du JWT) ---
-    identity = jwt_decoder.decode(jwt_token)
-    user_id: str = identity.user_id
-
-    # --- Classification (CPU-bound → thread pool) ---
-    try:
-        predictions = await asyncio.to_thread(classify_image, image_bytes)
-    except Exception:
-        raise HTTPException(status_code=422, detail="Image invalide ou corrompue.")
-    if not predictions:
-        raise HTTPException(status_code=422, detail="Aucun aliment détecté avec un score suffisant.")
-
-    # --- Lookup nutritionnel pour chaque aliment détecté ---
-    detected_foods = [
-        {"label": label, "confidence": score, "nutrition": lookup_nutrition(label, db)}
-        for label, score in predictions
-    ]
-
-    # --- Macros du repas (aliment le plus probable) ---
-    top_nutrition = detected_foods[0]["nutrition"]
-    macros: dict = {}
-    if top_nutrition:
-        macros = {
-            k: top_nutrition[k]
-            for k in ("calories", "protein_g", "carbs_g", "fat_g", "fiber_g")
-            if top_nutrition.get(k) is not None
-        }
-
-    # --- Objectifs nutritionnels + déséquilibres ---
-    goal = db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).first()
-    imbalances = _detect_imbalances(macros, goal)
-    recommendations = _build_recommendations(imbalances)
-
-    # --- Sauvegarde ---
-    analysis = MealAnalysis(
-        user_id=user_id,
-        detected_foods=detected_foods,
-        macros=macros,
-        confidence_scores={item["label"]: item["confidence"] for item in detected_foods},
-    )
-    db.add(analysis)
-    db.commit()
-    db.refresh(analysis)
-
-    return {
-        "analysis_id": analysis.id,
-        "detected_foods": detected_foods,
-        "macros": macros,
-        "imbalances": imbalances,
-        "recommendations": recommendations,
-    }
+    user_id = _user_id_from_auth(authorization)
+    return await orchestrate(image_bytes, user_id, db)

--- a/app/services/imbalance_detector.py
+++ b/app/services/imbalance_detector.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.db.models import NutritionGoal
+from app.models.schemas import Imbalance
+
+# Detection des desequilibres macros par rapport aux objectifs journaliers.
+#
+# Renvoie une liste de (Imbalance, message) ordonnee : calories -> proteines ->
+# glucides -> lipides. Cet ordre stable est utilise pour le hash de cache LLM
+# (issue NUT-11).
+
+_CALORIES_RATIO = 0.6
+_PROTEIN_RATIO = 0.2
+_CARBS_RATIO = 0.7
+_FAT_RATIO = 0.7
+
+
+def detect_imbalances(
+    macros: dict, goal: NutritionGoal | None
+) -> list[tuple[Imbalance, str]]:
+    if goal is None or not macros:
+        return []
+    issues: list[tuple[Imbalance, str]] = []
+
+    if goal.calories_target and macros.get("calories") is not None:
+        calories = macros["calories"]
+        ratio = calories / float(goal.calories_target)
+        if ratio > _CALORIES_RATIO:
+            issues.append(
+                (
+                    Imbalance.calories_high,
+                    f"Apport calorique eleve : {calories:.0f} kcal "
+                    f"({ratio:.0%} de l'objectif journalier de {goal.calories_target} kcal)",
+                )
+            )
+
+    if goal.protein_g and macros.get("protein_g") is not None:
+        protein = macros["protein_g"]
+        if protein < float(goal.protein_g) * _PROTEIN_RATIO:
+            issues.append(
+                (
+                    Imbalance.protein_low,
+                    f"Faible en proteines : {protein:.1f}g "
+                    f"(objectif journalier : {goal.protein_g}g)",
+                )
+            )
+
+    if goal.carbs_g and macros.get("carbs_g") is not None:
+        carbs = macros["carbs_g"]
+        if carbs > float(goal.carbs_g) * _CARBS_RATIO:
+            issues.append(
+                (
+                    Imbalance.carbs_high,
+                    f"Eleve en glucides : {carbs:.1f}g "
+                    f"(objectif journalier : {goal.carbs_g}g)",
+                )
+            )
+
+    if goal.fat_g and macros.get("fat_g") is not None:
+        fat = macros["fat_g"]
+        if fat > float(goal.fat_g) * _FAT_RATIO:
+            issues.append(
+                (
+                    Imbalance.fat_high,
+                    f"Eleve en lipides : {fat:.1f}g "
+                    f"(objectif journalier : {goal.fat_g}g)",
+                )
+            )
+
+    return issues

--- a/app/services/meal_analysis_orchestrator.py
+++ b/app/services/meal_analysis_orchestrator.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.data import recommendations_matrix as matrix
+from app.db.models import MealAnalysis, NutritionGoal
+from app.models.schemas import HealthGoal, Imbalance, RecommendationContext
+from app.services import llm_client
+from app.services.food_classifier import classify_image
+from app.services.imbalance_detector import detect_imbalances
+from app.services.nutrition_lookup import lookup_nutrition
+
+_LOGGER = logging.getLogger(__name__)
+
+# Mapping schemas.Imbalance -> matrix.Imbalance (4 cas detectables seulement).
+# Les 4 cles sont les seules que `imbalance_detector` peut produire.
+_IMBALANCE_TO_MATRIX: dict[Imbalance, matrix.Imbalance] = {
+    Imbalance.calories_high: matrix.Imbalance.HIGH_CALORIES,
+    Imbalance.protein_low: matrix.Imbalance.LOW_PROTEIN,
+    Imbalance.carbs_high: matrix.Imbalance.HIGH_CARBS,
+    Imbalance.fat_high: matrix.Imbalance.HIGH_FAT,
+}
+
+_DEFAULT_HEALTH_GOAL = HealthGoal.balance
+_CACHE_TTL_DAYS = 30
+_MACRO_KEYS = ("calories", "protein_g", "carbs_g", "fat_g", "fiber_g")
+
+
+async def analyze_meal(image_bytes: bytes, user_id: int, db: Session) -> dict[str, Any]:
+    """Pipeline complet : classification, lookup, imbalances, LLM, persistance."""
+    # 1. Classification HuggingFace (CPU-bound -> thread pool).
+    try:
+        predictions = await asyncio.to_thread(classify_image, image_bytes)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="Image invalide ou corrompue.") from exc
+    if not predictions:
+        raise HTTPException(
+            status_code=422, detail="Aucun aliment detecte avec un score suffisant."
+        )
+
+    # 2. Lookup nutrition pour chaque aliment detecte.
+    detected_foods = [
+        {"label": label, "confidence": score, "nutrition": lookup_nutrition(label, db)}
+        for label, score in predictions
+    ]
+
+    # 3. Macros du repas (aliment le plus probable).
+    top_label = predictions[0][0]
+    top_nutrition = detected_foods[0]["nutrition"] or {}
+    macros: dict[str, float] = {
+        k: top_nutrition[k] for k in _MACRO_KEYS if top_nutrition.get(k) is not None
+    }
+
+    # 4. Profil + desequilibres + objectif de sante.
+    goal = db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).one_or_none()
+    imbalances = detect_imbalances(macros, goal)
+    imbalance_messages = [msg for _, msg in imbalances]
+    imbalance_kinds = [kind for kind, _ in imbalances]
+    health_goal = _resolve_health_goal(goal)
+
+    # 5. Recommandations : cache, sinon LLM avec fallback matrice.
+    if not imbalance_kinds:
+        recommendations: list[str] = []
+        recommendations_hash: str | None = None
+        fallback_used = False
+    else:
+        recommendations_hash = compute_recommendations_hash(
+            top_label, health_goal, imbalance_kinds
+        )
+        cached = _lookup_cached_recommendations(db, recommendations_hash)
+        if cached is not None:
+            recommendations = cached
+            fallback_used = False
+        else:
+            recommendations, fallback_used = await _generate_recommendations(
+                user_id, imbalance_kinds, health_goal, db
+            )
+
+    # 6. Persistance. Hash NULL en mode fallback : un appel ulterieur retentera le LLM.
+    analysis = MealAnalysis(
+        user_id=user_id,
+        detected_foods=detected_foods,
+        macros=macros,
+        confidence_scores={item["label"]: item["confidence"] for item in detected_foods},
+        recommendations=recommendations,
+        recommendations_hash=None if fallback_used else recommendations_hash,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+
+    return {
+        "analysis_id": analysis.id,
+        "detected_foods": detected_foods,
+        "macros": macros,
+        "imbalances": imbalance_messages,
+        "recommendations": recommendations,
+        "fallback": fallback_used,
+    }
+
+
+def compute_recommendations_hash(
+    top_label: str, health_goal: HealthGoal, imbalances: list[Imbalance]
+) -> str:
+    """SHA256 hex de (top_label, health_goal, imbalances triees) en JSON canonique."""
+    canonical = {
+        "top_label": top_label,
+        "health_goal": health_goal.value,
+        "imbalances": sorted(i.value for i in imbalances),
+    }
+    serialized = json.dumps(canonical, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _resolve_health_goal(goal: NutritionGoal | None) -> HealthGoal:
+    if goal is None or not goal.health_goal:
+        return _DEFAULT_HEALTH_GOAL
+    try:
+        return HealthGoal(goal.health_goal)
+    except ValueError:
+        # Une valeur non standard en BDD (extremement improbable car CHECK V9) :
+        # on degrade vers balance plutot que crasher l'analyse.
+        _LOGGER.warning("health_goal inattendu en BDD : %r", goal.health_goal)
+        return _DEFAULT_HEALTH_GOAL
+
+
+def _lookup_cached_recommendations(db: Session, hash_value: str) -> list[str] | None:
+    """Cache global : si une analyse < 30 jours partage le meme hash, on la reutilise."""
+    row = db.execute(
+        text(
+            "SELECT recommendations FROM meal_analyses "
+            "WHERE recommendations_hash = :h "
+            f"AND created_at > NOW() - INTERVAL '{_CACHE_TTL_DAYS} days' "
+            "ORDER BY created_at DESC "
+            "LIMIT 1"
+        ),
+        {"h": hash_value},
+    ).fetchone()
+    if row is None:
+        return None
+    return list(row.recommendations) if row.recommendations else []
+
+
+async def _generate_recommendations(
+    user_id: int,
+    imbalances: list[Imbalance],
+    health_goal: HealthGoal,
+    db: Session,
+) -> tuple[list[str], bool]:
+    """Appelle generate_recommendation pour chaque desequilibre. fallback_used =
+    True si au moins un appel a echoue et a active la matrice statique."""
+    fallback_used = False
+
+    def _matrix_fallback(imb: Imbalance, goal: HealthGoal) -> str:
+        nonlocal fallback_used
+        fallback_used = True
+        mat_imb = _IMBALANCE_TO_MATRIX.get(imb)
+        if mat_imb is None:
+            return matrix.GENERIC_FALLBACK
+        try:
+            mat_goal = matrix.HealthGoal(goal.value)
+        except ValueError:
+            return matrix.GENERIC_FALLBACK
+        return matrix.get_recommendation(mat_imb, mat_goal)
+
+    recommendations: list[str] = []
+    for kind in imbalances:
+        ctx = RecommendationContext(
+            user_id=user_id, imbalance=kind, health_goal=health_goal
+        )
+        recommendations.append(
+            await llm_client.generate_recommendation(ctx, db, fallback=_matrix_fallback)
+        )
+    return recommendations, fallback_used

--- a/app/services/meal_analysis_orchestrator.py
+++ b/app/services/meal_analysis_orchestrator.py
@@ -133,16 +133,22 @@ def _resolve_health_goal(goal: NutritionGoal | None) -> HealthGoal:
 
 
 def _lookup_cached_recommendations(db: Session, hash_value: str) -> list[str] | None:
-    """Cache global : si une analyse < 30 jours partage le meme hash, on la reutilise."""
+    """Cache global : si une analyse < TTL jours partage le meme hash, on la reutilise.
+
+    Race condition assumee : deux requetes concurrentes avec le meme hash peuvent
+    declencher chacune un appel LLM avant que la premiere n'ecrive en BDD. La
+    seconde ecrasera juste l'entree avec une valeur equivalente. Volume actuel
+    trop faible pour justifier un INSERT ON CONFLICT.
+    """
     row = db.execute(
         text(
             "SELECT recommendations FROM meal_analyses "
             "WHERE recommendations_hash = :h "
-            f"AND created_at > NOW() - INTERVAL '{_CACHE_TTL_DAYS} days' "
+            "AND created_at > NOW() - make_interval(days => :ttl_days) "
             "ORDER BY created_at DESC "
             "LIMIT 1"
         ),
-        {"h": hash_value},
+        {"h": hash_value, "ttl_days": _CACHE_TTL_DAYS},
     ).fetchone()
     if row is None:
         return None
@@ -155,8 +161,12 @@ async def _generate_recommendations(
     health_goal: HealthGoal,
     db: Session,
 ) -> tuple[list[str], bool]:
-    """Appelle generate_recommendation pour chaque desequilibre. fallback_used =
-    True si au moins un appel a echoue et a active la matrice statique."""
+    """Appelle generate_recommendation pour chaque desequilibre.
+
+    fallback_used = True si AU MOINS UN appel a echoue et a active la matrice
+    statique. La liste retournee peut donc melanger des phrases LLM et matrice
+    dans ce cas ; le client n'a pas le detail granulaire.
+    """
     fallback_used = False
 
     def _matrix_fallback(imb: Imbalance, goal: HealthGoal) -> str:
@@ -171,12 +181,13 @@ async def _generate_recommendations(
             return matrix.GENERIC_FALLBACK
         return matrix.get_recommendation(mat_imb, mat_goal)
 
-    recommendations: list[str] = []
-    for kind in imbalances:
+    async def _one(kind: Imbalance) -> str:
         ctx = RecommendationContext(
             user_id=user_id, imbalance=kind, health_goal=health_goal
         )
-        recommendations.append(
-            await llm_client.generate_recommendation(ctx, db, fallback=_matrix_fallback)
-        )
-    return recommendations, fallback_used
+        return await llm_client.generate_recommendation(ctx, db, fallback=_matrix_fallback)
+
+    # Parallelise les appels LLM ; le semaphore d'llm_client plafonne deja la
+    # charge Ollama (max 2 inferences simultanees).
+    recommendations = await asyncio.gather(*(_one(k) for k in imbalances))
+    return list(recommendations), fallback_used

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from testcontainers.postgres import PostgresContainer
 
 MIGRATIONS_DIR = Path(os.environ.get("MIGRATIONS_DIR", "/migrations"))
 MIGRATION_PATTERN = re.compile(r"^V(\d+)__.*\.sql$")
-MAX_MIGRATION_VERSION = 9  # AC issue 23 : V1 a V9
+MAX_MIGRATION_VERSION = 10  # AC issue 26 : V1 a V10
 
 TEST_AUTH_SECRET = "test-secret-not-for-prod-do-not-use"
 TEST_OLLAMA_HOST = "http://ollama-test:11434"

--- a/tests/test_meal_analysis_api.py
+++ b/tests/test_meal_analysis_api.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Generator
+from io import BytesIO
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from PIL import Image
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+from tests.conftest import TEST_AUTH_SECRET
+
+
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+
+
+@pytest.fixture
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (4, 4), (255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _seed_pizza(db: Session) -> None:
+    """Pizza forte en calories et glucides (declenche calories_high + carbs_high
+    quand l'utilisateur a calories_target=2000 et carbs_g=200)."""
+    db.execute(
+        text(
+            "INSERT INTO nutrition_entries "
+            "(food_name, calories, protein_g, carbs_g, fat_g, fiber_g, source) "
+            "VALUES ('pizza', 1300, 30, 160, 50, 5, 'TEST')"
+        )
+    )
+    db.commit()
+
+
+def _seed_profile(
+    db: Session,
+    user_id: int,
+    *,
+    health_goal: str | None = "muscle_gain",
+    calories_target: int = 2000,
+    protein_g: float = 100.0,
+    carbs_g: float = 200.0,
+    fat_g: float = 80.0,
+) -> None:
+    db.execute(
+        text(
+            "INSERT INTO nutrition_goals "
+            "(user_id, health_goal, calories_target, protein_g, carbs_g, fat_g) "
+            "VALUES (:uid, :goal, :cal, :prot, :carb, :fat)"
+        ),
+        {
+            "uid": user_id,
+            "goal": health_goal,
+            "cal": calories_target,
+            "prot": protein_g,
+            "carb": carbs_g,
+            "fat": fat_g,
+        },
+    )
+    db.commit()
+
+
+def test_analyze_meal_nominal_returns_llm_recommendations(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 42
+    _seed_pizza(db_session)
+    _seed_profile(db_session, user_id)
+
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Reduis la portion au prochain repas.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is False
+    # Pizza : calories 1300/2000 = 65 % > 60 % et glucides 160/200 = 80 % > 70 %.
+    # Deux desequilibres -> deux appels LLM -> deux recommandations.
+    assert len(body["recommendations"]) == 2
+    assert all(r == "Reduis la portion au prochain repas." for r in body["recommendations"])
+    assert route.call_count == 2
+
+    row = db_session.execute(
+        text(
+            "SELECT user_id, recommendations, recommendations_hash "
+            "FROM meal_analyses WHERE user_id = :uid"
+        ),
+        {"uid": user_id},
+    ).fetchone()
+    assert row is not None
+    assert row.user_id == user_id
+    assert len(row.recommendations) == 2
+    assert row.recommendations_hash is not None
+    assert len(row.recommendations_hash) == 64
+
+
+def test_analyze_meal_falls_back_to_matrix_when_llm_down(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 43
+    _seed_pizza(db_session)
+    _seed_profile(db_session, user_id, health_goal="weight_loss")
+
+    # 503 sur tous les essais : llm_client epuise ses retries puis bascule sur le fallback.
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(503, json={"error": "down"})
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is True
+    assert len(body["recommendations"]) == 2
+    # Les phrases de la matrice contiennent des marqueurs (objectif perte de poids).
+    assert any("perte de poids" in r.lower() for r in body["recommendations"])
+
+    # Mode fallback : on ne pose pas le hash (un futur appel doit retenter le LLM).
+    row = db_session.execute(
+        text("SELECT recommendations_hash FROM meal_analyses WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    assert row is not None
+    assert row.recommendations_hash is None
+
+
+def test_analyze_meal_cache_hit_skips_llm_on_second_call(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 44
+    _seed_pizza(db_session)
+    _seed_profile(db_session, user_id, health_goal="balance")
+
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Garde une portion raisonnable.", "done": True}
+    )
+
+    headers = {"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"}
+
+    def _files() -> dict[str, tuple[str, bytes, str]]:
+        return {"photo": ("pizza.png", _png_bytes(), "image/png")}
+
+    first = client.post("/api/v1/analyze-meal", files=_files(), headers=headers)
+    assert first.status_code == 200
+    assert first.json()["fallback"] is False
+    first_calls = route.call_count
+    assert first_calls == 2
+
+    second = client.post("/api/v1/analyze-meal", files=_files(), headers=headers)
+    assert second.status_code == 200
+    body2 = second.json()
+    assert body2["fallback"] is False
+    assert body2["recommendations"] == first.json()["recommendations"]
+    # Cache hit : aucun appel LLM supplementaire.
+    assert route.call_count == first_calls
+
+
+def test_analyze_meal_uses_balance_when_health_goal_missing(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 45
+    _seed_pizza(db_session)
+    # Profil avec macros mais sans health_goal (NULL en BDD).
+    _seed_profile(db_session, user_id, health_goal=None)
+
+    captured_prompts: list[str] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured_prompts.append(httpx.Request.read(request).decode())
+        return httpx.Response(200, json={"response": "Conseil generique.", "done": True})
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=_record)
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is False
+    assert len(body["recommendations"]) >= 1
+    # Le LLM a bien ete appele avec health_goal=balance.
+    assert captured_prompts, "Aucun appel LLM enregistre"
+    assert all("balance" in p for p in captured_prompts)

--- a/tests/unit/test_imbalance_detector.py
+++ b/tests/unit/test_imbalance_detector.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.db.models import NutritionGoal
+from app.models.schemas import Imbalance
+from app.services.imbalance_detector import detect_imbalances
+
+
+def _goal(**kwargs) -> NutritionGoal:
+    """Construit un NutritionGoal sans BDD (objet detache, pour test pur)."""
+    return NutritionGoal(user_id=1, **kwargs)
+
+
+def test_no_goal_returns_empty_list() -> None:
+    assert detect_imbalances({"calories": 1500, "protein_g": 50}, None) == []
+
+
+def test_aligned_meal_returns_empty_list() -> None:
+    goal = _goal(
+        calories_target=2000,
+        protein_g=Decimal("100"),
+        carbs_g=Decimal("250"),
+        fat_g=Decimal("70"),
+    )
+    macros = {"calories": 600, "protein_g": 30, "carbs_g": 70, "fat_g": 20}
+    assert detect_imbalances(macros, goal) == []
+
+
+def test_high_calories_imbalance_yields_calories_high_kind() -> None:
+    goal = _goal(calories_target=2000)
+    macros = {"calories": 1500}  # 75 % du target, > 60 %
+
+    issues = detect_imbalances(macros, goal)
+
+    assert len(issues) == 1
+    kind, message = issues[0]
+    assert kind == Imbalance.calories_high
+    assert "1500" in message
+    assert "2000" in message
+
+
+def test_low_protein_imbalance_yields_protein_low_kind() -> None:
+    goal = _goal(protein_g=Decimal("100"))
+    macros = {"protein_g": 10}  # < 20 % du target
+
+    issues = detect_imbalances(macros, goal)
+
+    assert len(issues) == 1
+    kind, _ = issues[0]
+    assert kind == Imbalance.protein_low
+
+
+def test_high_carbs_imbalance_yields_carbs_high_kind() -> None:
+    goal = _goal(carbs_g=Decimal("200"))
+    macros = {"carbs_g": 180}  # > 70 % du target
+
+    issues = detect_imbalances(macros, goal)
+
+    assert [kind for kind, _ in issues] == [Imbalance.carbs_high]
+
+
+def test_high_fat_imbalance_yields_fat_high_kind() -> None:
+    goal = _goal(fat_g=Decimal("60"))
+    macros = {"fat_g": 50}  # > 70 % du target
+
+    issues = detect_imbalances(macros, goal)
+
+    assert [kind for kind, _ in issues] == [Imbalance.fat_high]
+
+
+def test_imbalance_skips_unset_macros() -> None:
+    goal = _goal(calories_target=2000, protein_g=Decimal("100"))
+    macros = {"calories": 1500}  # protein_g absent
+
+    issues = detect_imbalances(macros, goal)
+
+    assert [kind for kind, _ in issues] == [Imbalance.calories_high]
+
+
+def test_imbalance_returns_multiple_kinds_in_stable_order() -> None:
+    goal = _goal(
+        calories_target=2000,
+        protein_g=Decimal("100"),
+        carbs_g=Decimal("200"),
+        fat_g=Decimal("60"),
+    )
+    macros = {"calories": 1500, "protein_g": 5, "carbs_g": 180, "fat_g": 50}
+
+    issues = detect_imbalances(macros, goal)
+    kinds = [kind for kind, _ in issues]
+
+    # Ordre stable : calories, protein, carbs, fat (utile pour hash de cache).
+    assert kinds == [
+        Imbalance.calories_high,
+        Imbalance.protein_low,
+        Imbalance.carbs_high,
+        Imbalance.fat_high,
+    ]
+
+
+@pytest.mark.parametrize(
+    "ratio,expected",
+    [
+        (0.55, []),  # 55 % du target : pas d'alerte
+        (0.61, [Imbalance.calories_high]),  # > 60 % : alerte
+    ],
+)
+def test_calories_threshold_at_60_percent(ratio: float, expected: list[Imbalance]) -> None:
+    goal = _goal(calories_target=2000)
+    macros = {"calories": int(2000 * ratio)}
+    assert [kind for kind, _ in detect_imbalances(macros, goal)] == expected


### PR DESCRIPTION
Closes #26

Depend de la migration MSPR-DB V10 : whitefoxxyt/MSPR-HealthAI-Coach-BDD#5

## Summary

Refactor de `POST /api/v1/analyze-meal` pour generer les recommandations textuelles via `llm_client.generate_recommendation` (Ollama / Gemma3:4b) avec fallback automatique sur la matrice statique (NUT-10) et cache PostgreSQL TTL 30 jours.

- **Orchestration** : nouveau module `app/services/meal_analysis_orchestrator.py`, le router se contente de la validation HTTP/JWT.
- **Detection** : extraction dans `app/services/imbalance_detector.py`, retourne des tuples `(schemas.Imbalance, message)` pour piloter les appels LLM tout en conservant les messages utilisateur.
- **Cache** : SHA256 canonique de `(top_food_label, health_goal, imbalances)` stocke dans `meal_analyses.recommendations_hash` (V10). Cache hit -> aucun appel LLM. Cache miss -> appel LLM par desequilibre, persistance avec hash. En mode fallback, on laisse le hash NULL pour qu'un futur appel retente Ollama.
- **Fallback** : adapter `schemas.Imbalance` -> `matrix.Imbalance` ; quand le LLM echoue, la matrice (NUT-10) prend le relais et la reponse expose `fallback: true`.
- **health_goal** : si NULL en BDD, on utilise `balance` par defaut, le LLM est appele normalement.

## Test plan

- [x] `tests/unit/test_imbalance_detector.py` : 10 cas (no goal, aligned meal, chaque kind, ordre stable, seuil 60 %).
- [x] `tests/test_meal_analysis_api.py` : 4 flux integration testcontainers (nominal LLM, fallback 503, cache hit, default health_goal=balance).
- [x] Suite complete : 157 passed, 0 failed (coverage 96 %).
- [ ] Apres merge de la migration V10 cote MSPR-DB, verifier la CI sur `feat/nut-api-phases-4-6`.