### PR TITLE
[NUT-9] Endpoint POST /api/v1/generate-meal-plan + orchestrator + rate limit + bypass Premium

### DIFF
--- a/app/limiter.py
+++ b/app/limiter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from slowapi import Limiter
 
 from app.services import jwt_decoder
@@ -16,7 +16,7 @@ def _user_key(request: Request) -> str:
     if auth.startswith("Bearer "):
         try:
             identity = jwt_decoder.decode(auth.removeprefix("Bearer "))
-        except Exception:
+        except HTTPException:
             pass
         else:
             return f"user:{identity.user_id}"

--- a/app/limiter.py
+++ b/app/limiter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fastapi import Request
+from slowapi import Limiter
+
+from app.services import jwt_decoder
+
+
+def _user_key(request: Request) -> str:
+    """Clef de rate limit : user_id du JWT, sinon IP en fallback.
+
+    Si le JWT est absent ou invalide, l'endpoint repondra 401 ; le rate limit
+    par IP empeche juste un attaquant non authentifie d'epuiser le service.
+    """
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        try:
+            identity = jwt_decoder.decode(auth.removeprefix("Bearer "))
+        except Exception:
+            pass
+        else:
+            return f"user:{identity.user_id}"
+    if request.client is not None:
+        return f"ip:{request.client.host}"
+    return "anonymous"
+
+
+limiter = Limiter(key_func=_user_key)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.extension import _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
 
 from app.limiter import limiter

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
+from slowapi.errors import RateLimitExceeded
+from slowapi.extension import _rate_limit_exceeded_handler
+from slowapi.middleware import SlowAPIMiddleware
 
-from app.routers import health, meal_analysis, nutrition_goals
+from app.limiter import limiter
+from app.routers import health, meal_analysis, meal_plan, nutrition_goals
 
 app = FastAPI(
     title="MSPR HealthAI Coach — AI Nutrition",
@@ -8,6 +12,11 @@ app = FastAPI(
     version="1.0.0",
 )
 
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
+
 app.include_router(health.router)
 app.include_router(meal_analysis.router, prefix="/api/v1")
+app.include_router(meal_plan.router, prefix="/api/v1")
 app.include_router(nutrition_goals.router, prefix="/api/v1")

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -28,25 +28,6 @@ class MealAnalysisResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-# MealPlan
-
-class MealPlanRequest(BaseModel):
-    user_id: int
-    objective: str | None = None
-    constraints: dict = {}
-
-
-class MealPlanResponse(BaseModel):
-    id: int
-    user_id: int
-    plan: dict
-    objective: str | None
-    constraints: dict
-    generated_at: datetime
-
-    model_config = {"from_attributes": True}
-
-
 # NutritionGoal
 
 class NutritionGoalRequest(BaseModel):
@@ -88,6 +69,30 @@ class MealDay(BaseModel):
 
 
 class FallbackMealPlan(BaseModel):
+    fallback: bool
+    days: list[MealDay]
+
+
+# Generate-meal-plan : contrat d'API (issue NUT-9).
+
+
+class DietType(str, Enum):
+    omnivore = "omnivore"
+    vegetarien = "vegetarien"
+    vegan = "vegan"
+    sans_gluten = "sans_gluten"
+
+
+class MealPlanRequest(BaseModel):
+    health_goal: HealthGoal | None = None
+    allergies: list[str] = []
+    budget_eur_per_day: float | None = Field(default=None, ge=0)
+    diet_type: DietType
+    duration_days: int = Field(default=7, ge=1, le=30)
+
+
+class MealPlanResponse(BaseModel):
+    plan_id: int
     fallback: bool
     days: list[MealDay]
 

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.limiter import limiter
+from app.models.schemas import MealPlanRequest, MealPlanResponse
+from app.services import jwt_decoder, meal_plan_orchestrator
+
+# Note : pas de `from __future__ import annotations` ici. Slowapi enveloppe la
+# fonction et FastAPI doit pouvoir resoudre les types Pydantic au moment de
+# l'inspection. Avec l'import differe, MealPlanRequest reste un ForwardRef et
+# le decodage du body echoue (PydanticUserError "class-not-fully-defined").
+
+router = APIRouter(tags=["meal-plan"])
+
+
+def _auth(authorization: Optional[str]) -> tuple[int, str]:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authorization header invalide.")
+    token = authorization.removeprefix("Bearer ")
+    identity = jwt_decoder.decode(token)
+    try:
+        user_id = int(identity.user_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
+    return user_id, token
+
+
+@router.post("/generate-meal-plan", response_model=MealPlanResponse)
+@limiter.limit("10/hour;3/minute")
+async def generate_meal_plan(
+    request: Request,  # requis par SlowAPI pour key_func
+    payload: MealPlanRequest,
+    authorization: Optional[str] = Header(default=None),
+    db: Session = Depends(get_db),
+) -> MealPlanResponse:
+    user_id, token = _auth(authorization)
+    return await meal_plan_orchestrator.generate(user_id, payload, token, db)

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from sqlalchemy.orm import Session
 
@@ -16,7 +14,7 @@ from app.services import jwt_decoder, meal_plan_orchestrator
 router = APIRouter(tags=["meal-plan"])
 
 
-def _auth(authorization: Optional[str]) -> tuple[int, str]:
+def _auth(authorization: str | None) -> tuple[int, str]:
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Authorization header invalide.")
     token = authorization.removeprefix("Bearer ")
@@ -33,7 +31,7 @@ def _auth(authorization: Optional[str]) -> tuple[int, str]:
 async def generate_meal_plan(
     request: Request,  # requis par SlowAPI pour key_func
     payload: MealPlanRequest,
-    authorization: Optional[str] = Header(default=None),
+    authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ) -> MealPlanResponse:
     user_id, token = _auth(authorization)

--- a/app/services/meal_plan_orchestrator.py
+++ b/app/services/meal_plan_orchestrator.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.models.schemas import (
+    HealthGoal,
+    MealPlanRequest,
+    MealPlanResponse,
+    PlanInputs,
+)
+from app.services.entitlements_client import get_entitlements
+from app.services.fallback_loader import load_fallback_plan
+from app.services.llm_client import compute_inputs_hash, generate_plan
+from app.services.profile_service import get_profile
+
+# Tiers entitled au bypass cache : chaque appel re-genere via Ollama.
+_PREMIUM_TIERS = frozenset({"premium", "premium_plus"})
+
+
+async def generate(
+    user_id: int,
+    request: MealPlanRequest,
+    jwt: str,
+    db: Session,
+) -> MealPlanResponse:
+    """Genere un plan repas en composant llm_client + entitlements + profile.
+
+    - Resout health_goal : explicite > profil > balance.
+    - Bypass cache si tier in {premium, premium_plus} (issue NUT-5).
+    - Delegue cache + retry + fallback + persistance a llm_client.
+    """
+    health_goal = _resolve_health_goal(request.health_goal, user_id, db)
+
+    entitlements = await get_entitlements(str(user_id), jwt)
+    bypass_cache = entitlements.tier in _PREMIUM_TIERS
+
+    plan_inputs = _build_inputs(user_id, request, health_goal)
+
+    plan = await generate_plan(
+        plan_inputs,
+        db,
+        bypass_cache=bypass_cache,
+        fallback_loader=load_fallback_plan,
+    )
+
+    plan_id = _latest_plan_id(db, user_id, compute_inputs_hash(plan_inputs))
+    db.commit()
+
+    return MealPlanResponse(plan_id=plan_id, fallback=plan.fallback, days=plan.days)
+
+
+def _resolve_health_goal(
+    explicit: HealthGoal | None, user_id: int, db: Session
+) -> HealthGoal:
+    if explicit is not None:
+        return explicit
+    profile = get_profile(user_id, db)
+    if profile is not None and profile.health_goal:
+        return HealthGoal(profile.health_goal)
+    return HealthGoal.balance
+
+
+def _build_inputs(
+    user_id: int, request: MealPlanRequest, health_goal: HealthGoal
+) -> PlanInputs:
+    budget = (
+        Decimal(str(request.budget_eur_per_day))
+        if request.budget_eur_per_day is not None
+        else None
+    )
+    return PlanInputs(
+        user_id=user_id,
+        objective=health_goal.value,
+        duration_days=request.duration_days,
+        diet_type=request.diet_type.value,
+        allergies=request.allergies,
+        budget_per_day=budget,
+    )
+
+
+def _latest_plan_id(db: Session, user_id: int, inputs_hash: str) -> int:
+    """Recupere l'id du plan persiste : cache hit ou nouvelle insertion."""
+    row = db.execute(
+        text(
+            "SELECT id FROM meal_plans "
+            "WHERE user_id = :uid AND inputs_hash = :h "
+            "ORDER BY generated_at DESC LIMIT 1"
+        ),
+        {"uid": user_id, "h": inputs_hash},
+    ).fetchone()
+    if row is None:
+        # generate_plan persiste systematiquement (success / fallback / cache hit).
+        # Si on arrive ici c'est une erreur de logique amont.
+        raise RuntimeError("plan persiste introuvable apres generate_plan")
+    return int(row.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ transformers==4.51.3
 torch==2.7.0+cpu
 pyjwt==2.10.1
 cachetools==5.5.0
+slowapi==0.1.9
 pytest==8.3.4

--- a/tests/test_meal_plan_api.py
+++ b/tests/test_meal_plan_api.py
@@ -1,0 +1,641 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Generator
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.services import entitlements_client
+from app.services.entitlements_client import Entitlements
+from tests.conftest import TEST_AUTH_SECRET, TEST_OLLAMA_HOST
+
+
+def _ollama_payload(plan: dict[str, Any]) -> dict[str, Any]:
+    return {"response": json.dumps(plan), "done": True}
+
+
+def _valid_plan(marker_calories: int = 450) -> dict[str, Any]:
+    return {
+        "fallback": False,
+        "days": [
+            {
+                "day": 1,
+                "meals": [
+                    {
+                        "name": "Petit-dejeuner protein",
+                        "macros": {
+                            "calories": marker_calories,
+                            "protein_g": 30.0,
+                            "carbs_g": 40.0,
+                            "fat_g": 15.0,
+                        },
+                        "ingredients": ["avoine", "tofu"],
+                        "est_budget_eur": 2.5,
+                        "prep_time_min": 10,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+    monkeypatch.setattr(settings, "ollama_host", TEST_OLLAMA_HOST)
+    entitlements_client._cache.clear()
+    entitlements_client._stale.clear()
+
+
+@pytest.fixture(autouse=True)
+def _entitlements_free(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Par defaut : tier free. Les tests qui veulent premium appellent _set_tier."""
+    from app.services import meal_plan_orchestrator
+
+    holder: dict[str, str] = {"tier": "free"}
+
+    async def _fake_get(user_id: str, jwt: str) -> Entitlements:  # noqa: ARG001
+        return Entitlements(tier=holder["tier"], expires_at=None, features=())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(entitlements_client, "get_entitlements", _fake_get)
+    monkeypatch.setattr(meal_plan_orchestrator, "get_entitlements", _fake_get)
+
+    def _set_tier(tier: str) -> None:
+        holder["tier"] = tier
+
+    return _set_tier
+
+
+@pytest.fixture
+def set_tier(_entitlements_free: Callable[[str], None]) -> Callable[[str], None]:
+    return _entitlements_free
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter() -> None:
+    """Reset SlowAPI in-memory storage entre tests pour eviter la contamination."""
+    from app.limiter import limiter
+
+    limiter.reset()
+
+
+@pytest.fixture
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_generate_meal_plan_returns_200_with_plan_id_and_days(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=42)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["plan_id"] >= 1
+    assert body["fallback"] is False
+    assert isinstance(body["days"], list)
+    assert len(body["days"]) == 1
+    assert body["days"][0]["day"] == 1
+    assert body["days"][0]["meals"][0]["name"] == "Petit-dejeuner protein"
+
+
+def test_free_tier_cache_hit_skips_second_ollama_call(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Tier free + memes inputs : 2eme requete sert le cache, pas d'appel Ollama."""
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan(marker_calories=1234))
+    )
+    headers = {"Authorization": f"Bearer {valid_jwt(user_id=200)}"}
+    body = {
+        "health_goal": "balance",
+        "diet_type": "omnivore",
+        "duration_days": 1,
+        "allergies": [],
+        "budget_eur_per_day": 15,
+    }
+
+    first = client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+    second = client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert route.call_count == 1
+    # Le 2eme appel renvoie le plan cache (memes calories marker).
+    assert second.json()["days"][0]["meals"][0]["macros"]["calories"] == 1234
+
+
+def test_premium_tier_bypasses_cache_and_regenerates(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    set_tier: Callable[[str], None],
+) -> None:
+    """Tier premium : 2 appels memes inputs -> 2 generations distinctes."""
+    set_tier("premium")
+    plans = [_valid_plan(marker_calories=111), _valid_plan(marker_calories=222)]
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_payload(plans[0])),
+            httpx.Response(200, json=_ollama_payload(plans[1])),
+        ]
+    )
+    headers = {"Authorization": f"Bearer {valid_jwt(user_id=300)}"}
+    body = {
+        "health_goal": "balance",
+        "diet_type": "omnivore",
+        "duration_days": 1,
+        "allergies": [],
+        "budget_eur_per_day": 15,
+    }
+
+    first = client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+    second = client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert route.call_count == 2
+    assert first.json()["days"][0]["meals"][0]["macros"]["calories"] == 111
+    assert second.json()["days"][0]["meals"][0]["macros"]["calories"] == 222
+
+
+def test_premium_plus_tier_also_bypasses_cache(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    set_tier: Callable[[str], None],
+) -> None:
+    set_tier("premium_plus")
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+    headers = {"Authorization": f"Bearer {valid_jwt(user_id=301)}"}
+    body = {
+        "health_goal": "balance",
+        "diet_type": "omnivore",
+        "duration_days": 1,
+        "allergies": [],
+        "budget_eur_per_day": 15,
+    }
+
+    client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+    client.post("/api/v1/generate-meal-plan", json=body, headers=headers)
+
+    assert route.call_count == 2
+
+
+def test_falls_back_to_static_plan_when_ollama_unavailable(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Ollama down (503 sur tous les retries) : retombee sur les plans NUT-8."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        503, json={"error": "ollama down"}
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 7,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=400)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is True
+    # Le fallback NUT-8 pour balance / omnivore couvre 7 jours x 3 repas.
+    assert len(body["days"]) == 7
+    assert all(len(d["meals"]) == 3 for d in body["days"])
+
+
+def test_invalid_llm_json_retries_then_falls_back(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Ollama renvoie un JSON sans champs requis sur les 3 essais : fallback."""
+    invalid = {"days": "not a list"}  # rejete par Pydantic
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_payload(invalid)),
+            httpx.Response(200, json=_ollama_payload(invalid)),
+            httpx.Response(200, json=_ollama_payload(invalid)),
+        ]
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "weight_loss",
+            "diet_type": "vegetarien",
+            "duration_days": 7,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=410)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is True
+    assert route.call_count == 3  # 1 essai + 2 retries
+
+
+def test_invalid_then_valid_llm_returns_success_without_fallback(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Premier JSON invalide, retry produit JSON valide : pas de fallback."""
+    invalid = {"days": "not a list"}
+    valid = _valid_plan(marker_calories=777)
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_payload(invalid)),
+            httpx.Response(200, json=_ollama_payload(valid)),
+        ]
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=411)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["fallback"] is False
+    assert body["days"][0]["meals"][0]["macros"]["calories"] == 777
+    assert route.call_count == 2
+
+
+def test_health_goal_falls_back_to_profile_when_request_null(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """health_goal=null + profil "weight_loss" -> objective dans le prompt = weight_loss."""
+    # Pre-cree un profil nutritionnel pour user 500.
+    db_session.execute(
+        text(
+            "INSERT INTO nutrition_goals (user_id, health_goal, diet_type) "
+            "VALUES (500, 'weight_loss', 'omnivore')"
+        )
+    )
+    db_session.commit()
+
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": None,
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=500)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    sent_prompt = json.loads(route.calls.last.request.content)["prompt"]
+    assert "weight_loss" in sent_prompt
+    # On verifie en BDD que l'objective persiste correspond au profil.
+    objective = db_session.execute(
+        text("SELECT objective FROM meal_plans WHERE user_id = 500")
+    ).scalar()
+    assert objective == "weight_loss"
+
+
+def test_health_goal_defaults_to_balance_when_no_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """Pas de profil + health_goal=null : default 'balance'."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": None,
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=501)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    objective = db_session.execute(
+        text("SELECT objective FROM meal_plans WHERE user_id = 501")
+    ).scalar()
+    assert objective == "balance"
+
+
+def test_explicit_health_goal_overrides_profile(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """health_goal explicite != null : profil ignore."""
+    db_session.execute(
+        text(
+            "INSERT INTO nutrition_goals (user_id, health_goal, diet_type) "
+            "VALUES (502, 'weight_loss', 'omnivore')"
+        )
+    )
+    db_session.commit()
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "muscle_gain",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=502)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    objective = db_session.execute(
+        text("SELECT objective FROM meal_plans WHERE user_id = 502")
+    ).scalar()
+    assert objective == "muscle_gain"
+
+
+def test_rate_limit_returns_429_after_threshold(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    set_tier: Callable[[str], None],
+) -> None:
+    """11eme requete dans la fenetre depasse 10/heure (ou 3/min) -> 429."""
+    # Tier premium pour bypasser le cache : sinon les requetes apres la 1ere
+    # frappent le cache et la limite ne se declenche pas (selon implementation).
+    # Le rate limit fastapi/slowapi compte les requetes peu importe le cache.
+    set_tier("premium")
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+    headers = {"Authorization": f"Bearer {valid_jwt(user_id=600)}"}
+    body = {
+        "health_goal": "balance",
+        "diet_type": "omnivore",
+        "duration_days": 1,
+        "allergies": [],
+        "budget_eur_per_day": 15,
+    }
+
+    statuses = [
+        client.post("/api/v1/generate-meal-plan", json=body, headers=headers).status_code
+        for _ in range(11)
+    ]
+
+    # Au moins une 429 dans les 11 requetes (3/minute declenche au 4e, ou 10/hour au 11e).
+    assert 429 in statuses, statuses
+    assert statuses[-1] == 429
+
+
+def test_rate_limit_keys_by_user_id_not_ip(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    set_tier: Callable[[str], None],
+) -> None:
+    """Deux users distincts depuis la meme IP : leurs quotas sont independants."""
+    set_tier("premium")
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+    body = {
+        "health_goal": "balance",
+        "diet_type": "omnivore",
+        "duration_days": 1,
+        "allergies": [],
+        "budget_eur_per_day": 15,
+    }
+
+    # User 700 : epuise sa limite de minute (3 + 1 -> 429).
+    headers_700 = {"Authorization": f"Bearer {valid_jwt(user_id=700)}"}
+    for _ in range(3):
+        client.post("/api/v1/generate-meal-plan", json=body, headers=headers_700)
+    blocked = client.post("/api/v1/generate-meal-plan", json=body, headers=headers_700)
+    assert blocked.status_code == 429
+
+    # User 701 : son quota n'est pas affecte.
+    headers_701 = {"Authorization": f"Bearer {valid_jwt(user_id=701)}"}
+    fresh = client.post("/api/v1/generate-meal-plan", json=body, headers=headers_701)
+    assert fresh.status_code == 200, fresh.text
+
+
+def test_successful_generation_persists_row_with_inputs_hash(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """Chaque generation reussie cree une ligne meal_plans avec inputs_hash rempli."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "muscle_gain",
+            "diet_type": "vegetarien",
+            "duration_days": 3,
+            "allergies": ["arachides"],
+            "budget_eur_per_day": 12,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=800)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    row = db_session.execute(
+        text(
+            "SELECT id, user_id, inputs_hash, plan, objective "
+            "FROM meal_plans WHERE user_id = 800"
+        )
+    ).fetchone()
+    assert row is not None
+    assert row.user_id == 800
+    assert row.inputs_hash is not None
+    # SHA256 hex = 64 caracteres.
+    assert len(row.inputs_hash) == 64
+    assert row.objective == "muscle_gain"
+    assert response.json()["plan_id"] == row.id
+
+
+def test_fallback_generation_also_persists_row(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """Le mode degrade insere aussi une ligne meal_plans (avec fallback=true)."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(503, json={"error": "down"})
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 7,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=801)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    rows = db_session.execute(
+        text("SELECT id, inputs_hash, plan FROM meal_plans WHERE user_id = 801")
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0].inputs_hash is not None
+    assert rows[0].plan["fallback"] is True
+
+
+# Validation des inputs et de l'authentification
+
+
+def test_missing_authorization_returns_401(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "omnivore"},
+    )
+    assert response.status_code == 401
+
+
+def test_invalid_jwt_returns_401(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "omnivore"},
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert response.status_code == 401
+
+
+def test_jwt_with_non_numeric_sub_returns_401(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id="uuid-not-a-number")  # type: ignore[arg-type]
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "omnivore"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+def test_invalid_diet_type_returns_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "carnivore", "duration_days": 1},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=900)}"},
+    )
+    assert response.status_code == 422
+
+
+def test_invalid_health_goal_returns_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "omnivore", "health_goal": "marathon"},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=901)}"},
+    )
+    assert response.status_code == 422
+
+
+def test_negative_duration_returns_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"diet_type": "omnivore", "duration_days": 0},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=902)}"},
+    )
+    assert response.status_code == 422
+
+
+def test_missing_diet_type_returns_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={"duration_days": 7},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=903)}"},
+    )
+    assert response.status_code == 422

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -38,6 +38,8 @@ def test_openapi_lists_versioned_route():
     paths = response.json()["paths"]
     assert "/api/v1/analyze-meal" in paths
     assert "/api/v1/nutrition-goals/me" in paths
+    assert "/api/v1/generate-meal-plan" in paths
     assert "/health" in paths
     assert "/analyze-meal" not in paths
     assert "/nutrition-goals/me" not in paths
+    assert "/generate-meal-plan" not in paths

--- a/tests/unit/test_limiter_key.py
+++ b/tests/unit/test_limiter_key.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.config import settings
+from app.limiter import _user_key
+from tests.conftest import TEST_AUTH_SECRET
+
+
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+
+
+def _request(headers: dict[str, str] | None = None, client_host: str | None = "1.2.3.4") -> MagicMock:
+    req = MagicMock()
+    req.headers.get = (headers or {}).get
+    if client_host is None:
+        req.client = None
+    else:
+        req.client = MagicMock(host=client_host)
+    return req
+
+
+def test_key_uses_user_id_for_valid_jwt(valid_jwt: Callable[..., str]) -> None:
+    token = valid_jwt(user_id=42)
+    key = _user_key(_request({"Authorization": f"Bearer {token}"}))
+    assert key == "user:42"
+
+
+def test_key_falls_back_to_ip_when_no_authorization() -> None:
+    key = _user_key(_request({}))
+    assert key == "ip:1.2.3.4"
+
+
+def test_key_falls_back_to_ip_when_jwt_invalid() -> None:
+    key = _user_key(_request({"Authorization": "Bearer not-a-jwt"}))
+    assert key == "ip:1.2.3.4"
+
+
+def test_key_falls_back_to_anonymous_without_client() -> None:
+    key = _user_key(_request({}, client_host=None))
+    assert key == "anonymous"


### PR DESCRIPTION
Closes #27

## Summary

- Endpoint `POST /api/v1/generate-meal-plan` qui genere un plan repas via Ollama Gemma3:4b en composant `llm_client` (cache + retry + fallback NUT-8) avec `entitlements_client` (bypass cache si tier in `{premium, premium_plus}`) et `profile_service` (resolution `health_goal` : explicite > profil > `balance`).
- Orchestrator `services/meal_plan_orchestrator.py` testable hors FastAPI. Le router reste fin (~15 lignes : auth + appel orchestrator).
- SlowAPI `@limiter.limit("10/hour;3/minute")` keye sur `user_id` du JWT (fallback IP).
- Schemas Pydantic `MealPlanRequest`, `MealPlanResponse`, `DietType` au contrat NUT-9 ; `FallbackMealPlan` reste pour la sortie LLM brute.
- Persistance dans `meal_plans` avec `inputs_hash` SHA256 (deja gere par `llm_client`).

## Test plan

- [x] `pytest -m "not slow"` : 121 tests passent
- [x] Coverage globale 86% (orchestrator 95%, router 100%, limiter 100%, schemas 100%)
- [x] `ruff check .` : clean
- [ ] Smoke test manuel : `POST /api/v1/generate-meal-plan` avec JWT valide -> 200, body conforme
- [ ] Verifier Swagger UI sur `/docs` liste l'endpoint

## Notes

- `from __future__ import annotations` est intentionnellement absent de `app/routers/meal_plan.py` : SlowAPI enveloppe la fonction et FastAPI doit pouvoir resoudre les types Pydantic au moment de l'inspection. Avec l'import differe, `MealPlanRequest` reste un `ForwardRef` et le decodage du body echoue (`PydanticUserError "class-not-fully-defined"`). Documente dans le fichier.
- Les anciens schemas `MealPlanRequest`/`MealPlanResponse` (CRUD-style, jamais utilises) sont remplaces par le contrat NUT-9.