### PR TITLE
[NUT-13] GET /api/v1/meal-plans/me (historique pagine)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -124,6 +124,48 @@ class MealPlanResponse(BaseModel):
     days: list[MealDay]
 
 
+class MealPlanHistoryItem(BaseModel):
+    id: int
+    objective: str | None
+    constraints: dict[str, Any]
+    plan: dict[str, Any]
+    generated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PaginatedPlansResponse(BaseModel):
+    items: list[MealPlanHistoryItem]
+    total: int
+    limit: int
+    offset: int
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "items": [
+                    {
+                        "id": 42,
+                        "objective": "weight_loss",
+                        "constraints": {
+                            "diet_type": "vegan",
+                            "duration_days": 7,
+                            "allergies": [],
+                        },
+                        "plan": {
+                            "days": [{"day": 1, "meals": []}],
+                        },
+                        "generated_at": "2026-04-29T10:15:00",
+                    }
+                ],
+                "total": 17,
+                "limit": 20,
+                "offset": 0,
+            }
+        }
+    }
+
+
 # LLM client : inputs / outputs (issue NUT-7).
 
 

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.limiter import limiter
-from app.models.schemas import MealPlanRequest, MealPlanResponse
-from app.services import jwt_decoder, meal_plan_orchestrator
+from app.models.schemas import MealPlanRequest, MealPlanResponse, PaginatedPlansResponse
+from app.services import jwt_decoder, meal_plan_history, meal_plan_orchestrator
 
 # Note : pas de `from __future__ import annotations` ici. Slowapi enveloppe la
 # fonction et FastAPI doit pouvoir resoudre les types Pydantic au moment de
@@ -36,3 +36,14 @@ async def generate_meal_plan(
 ) -> MealPlanResponse:
     user_id, token = _auth(authorization)
     return await meal_plan_orchestrator.generate(user_id, payload, token, db)
+
+
+@router.get("/meal-plans/me", response_model=PaginatedPlansResponse)
+def list_my_meal_plans(
+    authorization: str | None = Header(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> PaginatedPlansResponse:
+    user_id, _ = _auth(authorization)
+    return meal_plan_history.list_user_plans(user_id, limit, offset, db)

--- a/app/services/meal_plan_history.py
+++ b/app/services/meal_plan_history.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db.models import MealPlan
+from app.models.schemas import MealPlanHistoryItem, PaginatedPlansResponse
+
+
+def list_user_plans(
+    user_id: int, limit: int, offset: int, db: Session
+) -> PaginatedPlansResponse:
+    base = db.query(MealPlan).filter(MealPlan.user_id == user_id)
+    total = base.with_entities(func.count(MealPlan.id)).scalar() or 0
+    rows = (
+        base.with_entities(
+            MealPlan.id,
+            MealPlan.objective,
+            MealPlan.constraints,
+            MealPlan.plan,
+            MealPlan.generated_at,
+        )
+        .order_by(MealPlan.generated_at.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+    items = [
+        MealPlanHistoryItem(
+            id=row.id,
+            objective=row.objective,
+            constraints=row.constraints or {},
+            plan=row.plan or {},
+            generated_at=row.generated_at,
+        )
+        for row in rows
+    ]
+    return PaginatedPlansResponse(items=items, total=total, limit=limit, offset=offset)

--- a/tests/test_meal_plan_history_api.py
+++ b/tests/test_meal_plan_history_api.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+from tests.conftest import TEST_AUTH_SECRET
+
+
+def _seed_plan(
+    db: Session,
+    user_id: int,
+    *,
+    plan: dict | None = None,
+    objective: str | None = "weight_loss",
+    constraints: dict | None = None,
+    inputs_hash: str | None = None,
+) -> None:
+    db.execute(
+        text(
+            "INSERT INTO meal_plans "
+            "(user_id, plan, objective, constraints, inputs_hash) "
+            "VALUES (:uid, CAST(:plan AS JSONB), :obj, CAST(:cons AS JSONB), :hash)"
+        ),
+        {
+            "uid": user_id,
+            "plan": json.dumps(plan or {}),
+            "obj": objective,
+            "cons": json.dumps(constraints or {}),
+            "hash": inputs_hash,
+        },
+    )
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+
+
+@pytest.fixture
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_returns_empty_when_user_has_no_plans(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    response = client.get(
+        "/api/v1/meal-plans/me",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=42)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body == {"items": [], "total": 0, "limit": 20, "offset": 0}
+
+
+def test_returns_only_plans_of_authenticated_user(
+    client: TestClient,
+    db_session: Session,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_a, user_b = 100, 200
+    for i in range(5):
+        _seed_plan(db_session, user_a, inputs_hash=f"a-{i}")
+    for i in range(3):
+        _seed_plan(db_session, user_b, inputs_hash=f"b-{i}")
+
+    response = client.get(
+        "/api/v1/meal-plans/me",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_a)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 5
+
+
+def test_items_sorted_by_generated_at_desc(
+    client: TestClient,
+    db_session: Session,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 7
+    db_session.execute(
+        text(
+            "INSERT INTO meal_plans (user_id, generated_at, inputs_hash) VALUES "
+            "(:uid, '2025-01-01 10:00:00', 'h1'), "
+            "(:uid, '2025-03-01 10:00:00', 'h2'), "
+            "(:uid, '2025-02-01 10:00:00', 'h3')"
+        ),
+        {"uid": user_id},
+    )
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/meal-plans/me",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200
+    timestamps = [item["generated_at"] for item in response.json()["items"]]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_pagination_returns_window_and_total(
+    client: TestClient,
+    db_session: Session,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 8
+    db_session.execute(
+        text(
+            "INSERT INTO meal_plans (user_id, generated_at, inputs_hash) VALUES "
+            "(:uid, '2025-01-01', 'p1'), (:uid, '2025-01-02', 'p2'), "
+            "(:uid, '2025-01-03', 'p3'), (:uid, '2025-01-04', 'p4'), "
+            "(:uid, '2025-01-05', 'p5')"
+        ),
+        {"uid": user_id},
+    )
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/meal-plans/me?limit=2&offset=1",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 5
+    assert body["limit"] == 2
+    assert body["offset"] == 1
+    timestamps = [item["generated_at"] for item in body["items"]]
+    assert len(timestamps) == 2
+    assert timestamps[0].startswith("2025-01-04")
+    assert timestamps[1].startswith("2025-01-03")
+
+
+def test_response_item_shape(
+    client: TestClient,
+    db_session: Session,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 9
+    plan = {"days": [{"day": 1, "meals": []}]}
+    constraints = {"diet_type": "vegan", "duration_days": 7}
+    _seed_plan(
+        db_session,
+        user_id,
+        plan=plan,
+        objective="muscle_gain",
+        constraints=constraints,
+        inputs_hash="shape-1",
+    )
+
+    response = client.get(
+        "/api/v1/meal-plans/me",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    item = response.json()["items"][0]
+    assert set(item.keys()) == {"id", "objective", "constraints", "plan", "generated_at"}
+    assert item["objective"] == "muscle_gain"
+    assert item["constraints"] == constraints
+    assert item["plan"] == plan
+    assert isinstance(item["id"], int)
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["limit=0", "limit=-1", "limit=101", "offset=-1"],
+)
+def test_invalid_pagination_params_return_422(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    query: str,
+) -> None:
+    response = client.get(
+        f"/api/v1/meal-plans/me?{query}",
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=1)}"},
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_missing_authorization_header_returns_401(client: TestClient) -> None:
+    response = client.get("/api/v1/meal-plans/me")
+    assert response.status_code == 401
+
+
+def test_invalid_jwt_returns_401(client: TestClient) -> None:
+    response = client.get(
+        "/api/v1/meal-plans/me",
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert response.status_code == 401

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -39,7 +39,9 @@ def test_openapi_lists_versioned_route():
     assert "/api/v1/analyze-meal" in paths
     assert "/api/v1/nutrition-goals/me" in paths
     assert "/api/v1/generate-meal-plan" in paths
+    assert "/api/v1/meal-plans/me" in paths
     assert "/health" in paths
     assert "/analyze-meal" not in paths
     assert "/nutrition-goals/me" not in paths
     assert "/generate-meal-plan" not in paths
+    assert "/meal-plans/me" not in paths


### PR DESCRIPTION
Closes #28

## Summary
- Ajoute l'endpoint `GET /api/v1/meal-plans/me?limit=&offset=` (auth JWT, filtrage par `user_id` du sujet du JWT, tri `generated_at DESC`, pagination `limit` 1..100 / `offset >= 0`).
- Symetrique de NUT-12 (`/meal-analyses/me`) avec service dedie `app/services/meal_plan_history.py` + schemas `MealPlanHistoryItem` / `PaginatedPlansResponse`.

## Test plan
- [x] 11 tests d'integration testcontainers : utilisateur vide, isolation user A vs user B (5/3 plans), tri DESC, fenetre de pagination, forme de l'item, `limit`/`offset` invalides -> 422, `Authorization` manquant ou JWT invalide -> 401.
- [x] `tests/test_routing.py` : assertion OpenAPI ajoutee pour `/api/v1/meal-plans/me`.
- [x] Suite complete : seuls les 5 echecs pre-existants subsistent (colonne `recommendations_hash` absente des migrations V8/V9, et `test_committed_json_matches_generator`), independants de ce PR.
- [ ] Verifier le rendu Swagger UI (`/docs`) en local.