### PR TITLE
[NUT-16] OpenAPI enrichie (descriptions, examples, tags) + README final

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,133 @@
 
 [![CI](https://github.com/whitefoxxyt/MSPR-HealthAI-Coach-AI-Nutrition/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/whitefoxxyt/MSPR-HealthAI-Coach-AI-Nutrition/actions/workflows/ci.yml)
 
-Micro-service d'analyse nutritionnelle par IA, partie de la plateforme HealthAI Coach (MSPR2).
+Micro-service FastAPI d'analyse nutritionnelle et de generation de plans repas par IA, partie de la plateforme MSPR HealthAI Coach (MSPR2).
+
+Le service fait deux choses :
+
+1. **Analyse de repas** : photo en entree, classification HuggingFace (`nateraw/food`, modele Food-101), lookup nutritionnel sur les datasets ETL, detection de desequilibres macros vs profil utilisateur, et recommandations generees par Ollama (Gemma3:4b) avec fallback matrice statique.
+2. **Generation de plans repas** : objectif sante, regime, allergies et budget, prompt structure soumis a Ollama, validation du JSON, persistance du plan sur 1 a 30 jours.
+
+Le PRD complet est l'issue [#15](https://github.com/whitefoxxyt/MSPR-HealthAI-Coach-AI-Nutrition/issues/15).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Client[Client mobile / web]
+  Auth[MSPR-AUTH<br/>:3000]
+  AI[MSPR-AI-Nutrition<br/>:8001]
+  Ollama[Ollama<br/>Gemma3:4b]
+  PG[(PostgreSQL<br/>healthai)]
+
+  Client -- "POST /sign-in" --> Auth
+  Auth -- "JWT HS256" --> Client
+  Client -- "Bearer JWT" --> AI
+  AI -- "decode local<br/>BETTER_AUTH_SECRET" --> AI
+  AI -- "GET /entitlements/me" --> Auth
+  AI -- "POST /api/generate" --> Ollama
+  AI -- "meal_analyses<br/>meal_plans<br/>nutrition_goals<br/>nutrition_entries" --> PG
+```
+
+- Le JWT est decode localement (HS256, secret partage avec MSPR-AUTH). Pas d'aller-retour reseau pour resoudre `user_id`.
+- Les entitlements (tier `free` / `premium` / `premium_plus`) sont lus chez MSPR-AUTH avec un cache TTL 60 s pour borner la latence.
+- La BDD `healthai` est partagee avec le reste de la plateforme. Les migrations appartiennent a [MSPR-DB](https://github.com/whitefoxxyt/MSPR-HealthAI-Coach-DB) (voir [`data_model.md`](https://github.com/whitefoxxyt/MSPR-HealthAI-Coach-DB/blob/main/docs/data_model.md)).
 
 ## Stack
 
-- **FastAPI** : API REST
-- **HuggingFace Transformers** : classification d'aliments depuis photo
-- **Ollama + Gemma3:4b** : génération de plans repas personnalisés (JSON)
-- **PostgreSQL** : stockage des analyses et plans générés
+| Composant | Role |
+|-----------|------|
+| FastAPI 0.115 + Uvicorn | Serveur HTTP, OpenAPI auto |
+| HuggingFace Transformers (`nateraw/food`) | Classification d'aliments depuis photo |
+| PyTorch 2.7.0 (CPU) | Inference du modele HuggingFace |
+| Ollama + Gemma3:4b | Generation des recommandations et plans repas |
+| PostgreSQL 17 | Stockage des analyses, plans, profils nutritionnels |
+| SQLAlchemy 2.0 | ORM |
+| Pydantic v2 + pydantic-settings | Validation des schemas et de la configuration |
+| SlowAPI | Rate limiting (10/h, 3/min sur `/generate-meal-plan`) |
+| pytest + testcontainers + respx | Tests unitaires, integration et mocks HTTP |
+
+## Demarrage local
+
+```bash
+# Service standalone (ne lance pas la plateforme entiere)
+cp .env.example .env
+docker compose up -d --build
+
+curl http://localhost:8001/health
+open http://localhost:8001/docs
+```
+
+Pour lancer la stack complete (DB, AUTH, API, FRONT, ce service) :
+
+```bash
+cd /home/arthur/Projects/MSPR
+docker compose up -d --build
+```
+
+Au premier demarrage, Ollama telecharge `gemma3:4b` (~3 Go). Le service repond sur `:8001` mais les recommandations basculent en mode fallback tant que le modele n'est pas pret.
+
+## Variables d'environnement
+
+| Variable | Defaut | Role |
+|----------|--------|------|
+| `DB_HOST` | `mspr-healthai-db` | Hote PostgreSQL |
+| `DB_PORT` | `5432` | Port PostgreSQL |
+| `DB_NAME` | `healthai` | Nom de la base |
+| `DB_USER` | `healthai_user` | Utilisateur PostgreSQL |
+| `DB_PASSWORD` | `password` | Mot de passe PostgreSQL |
+| `OLLAMA_HOST` | `http://ollama:11434` | URL du serveur Ollama |
+| `BETTER_AUTH_SECRET` | `""` | Secret HS256 partage avec MSPR-AUTH (obligatoire en prod) |
+| `AUTH_API_URL` | `http://mspr-healthai-auth:3000` | URL de MSPR-AUTH (entitlements) |
 
 ## Endpoints
 
-| Endpoint | Description |
-|----------|-------------|
-| `POST /analyze-meal` | Analyse photo → macros + déséquilibres |
-| `POST /generate-meal-plan` | Génération plan repas personnalisé |
-| `GET /meal-plans/{user_id}` | Historique des plans générés |
-| `GET /meal-analyses/{user_id}` | Historique des analyses |
-| `GET /health` | Healthcheck |
+OpenAPI complet sur `/docs` (Swagger UI) et `/redoc`.
 
-## Démarrage
+| Methode | Route | Tag | Description |
+|---------|-------|-----|-------------|
+| GET | `/health` | Sante | Healthcheck (PostgreSQL + Ollama) |
+| POST | `/api/v1/analyze-meal` | Analyse | Analyse une photo de repas (macros + recommandations) |
+| GET | `/api/v1/meal-analyses/me` | Historique | Historique pagine des analyses |
+| POST | `/api/v1/generate-meal-plan` | Plans | Generation d'un plan repas personnalise (1 a 30 jours) |
+| GET | `/api/v1/meal-plans/me` | Historique | Historique pagine des plans repas |
+| GET | `/api/v1/nutrition-goals/me` | Profil | Lecture du profil nutritionnel |
+| PUT | `/api/v1/nutrition-goals/me` | Profil | Creation ou mise a jour du profil nutritionnel (upsert) |
 
-```bash
-# À venir
-```
+Toutes les routes `/api/v1/*` requierent un header `Authorization: Bearer <jwt>`. Le JWT est emis par MSPR-AUTH (`POST /api/auth/sign-in`).
+
+Codes d'erreur retournes :
+
+- `401` : JWT manquant, malforme ou invalide.
+- `404` : profil nutritionnel non encore configure.
+- `413` : photo > 10 Mo.
+- `415` : type MIME non supporte (utiliser JPEG, PNG, WebP).
+- `422` : payload invalide ou image illisible.
+- `429` : rate limit depasse (`/generate-meal-plan` : 10/h et 3/min).
+- `503` : Ollama et fallback statique tous indisponibles.
 
 ## Tests
 
-Le harnais utilise pytest + testcontainers (PostgreSQL ephemere) + respx (mocks HTTP).
+Le harnais utilise pytest, testcontainers (PostgreSQL ephemere) et respx (mocks HTTP).
+
 Structure :
 
 ```
 tests/
-├── conftest.py     # 5 fixtures partagees (pg_container, db_session, mock_ollama, mock_classifier, valid_jwt)
-├── unit/           # tests purs, sans IO (rapides)
-├── integration/    # tests contre PG ephemere via testcontainers
-└── slow/           # smoke tests dependances externes (Ollama, HuggingFace), exclus du CI
+├── conftest.py              fixtures partagees (pg_container, db_session, mock_ollama, mock_classifier, valid_jwt)
+├── test_openapi_doc.py      verifie la richesse de la doc OpenAPI
+├── test_routing.py          smoke tests des prefixes
+├── test_meal_analysis_api.py
+├── test_meal_analysis_history_api.py
+├── test_meal_plan_api.py
+├── test_nutrition_goals_api.py
+├── unit/                    tests purs (sans IO)
+└── slow/                    smoke tests dependances reelles (Ollama, HuggingFace), exclus du CI
 ```
 
 ### Lancer la suite
 
-Conteneur (recommandé, isole testcontainers du host) :
+Conteneur (recommande, isole testcontainers du host) :
 
 ```bash
 docker compose --profile test build tests
@@ -58,8 +144,42 @@ MIGRATIONS_DIR=../MSPR-DB/migrations pytest                # unit + integration
 MIGRATIONS_DIR=../MSPR-DB/migrations pytest -m slow        # tests dependances externes
 ```
 
-### Couverture
+Couverture cible : > 80 %. Etat actuel : ~96 %. Rapport HTML genere dans `htmlcov/`.
 
-Cible : > 80% global. L'enforcement `--cov-fail-under=80` sera active une fois
-les phases 4-6 livrees ; le harnais actuel est un echafaudage.
-Rapport HTML genere dans `htmlcov/` apres chaque run.
+## Metriques IA
+
+Le PDF MSPR exige des metriques de qualite pour les 2 modeles IA : classifier HuggingFace (`nateraw/food`) et LLM Ollama (`gemma3:4b`). Le rapport complet est dans [`docs/metrics.md`](docs/metrics.md). Le script `scripts/eval_metrics.py` produit `docs/metrics.json` (brut) et `docs/metrics.md` (rendered, avec PNGs).
+
+### Reproduction des metriques
+
+```bash
+pip install -r requirements-eval.txt
+
+# Classifier : 1000 images Food-101 + 50 photos terrain (si annotees)
+python scripts/eval_metrics.py classifier --n-food101 1000 --seed 42
+
+# LLM : 100 generations + 30 plans contraints + HITL CSV
+python scripts/eval_metrics.py llm --n-generations 100 --seed 42
+```
+
+Les deux sous-commandes ecrivent dans `docs/metrics.json` (merge) puis re-rendent `docs/metrics.md` complet.
+
+### Datasets HITL
+
+Les annotations humaines sont decouplees du code :
+
+- `data/eval_terrain/labels.csv` : 50 photos terrain. Cf. `data/eval_terrain/README.md`.
+- `docs/llm_hitl_ratings.csv` : 20 plans notes 1-5 sur nutrition + originalite + coherence. Cf. `docs/llm_hitl_README.md`.
+
+Sans ces CSV, les sections terrain/HITL sont omises du rapport mais les metriques quantitatives restent calculees.
+
+### Reproductibilite
+
+Seed fixe (`--seed 42` par defaut). Les chiffres restent stables a +/- 5 % d'une execution a l'autre tant que les modeles ne changent pas (HuggingFace `nateraw/food`, Ollama `gemma3:4b`). La temperature LLM est par defaut, donc une variance residuelle persiste sur les latences et la generation.
+
+## Limitations connues
+
+- **Modele Food-101** : 101 classes occidentales, biais de domaine sur les photos prises au telephone (eclairage, angle). Voir `docs/model_benchmark.md`.
+- **Inference CPU** : pas de GPU dans cette image. Une analyse prend 1-3 s, une generation LLM 5-30 s.
+- **Cache LLM** : 30 jours par hash `(top_label, health_goal, imbalances)` pour `/analyze-meal`, hash inputs pour `/generate-meal-plan`. Les comptes `premium` bypassent le cache.
+- **Ollama** : pas de garantie de disponibilite, fallback matrice statique systematique pour `/analyze-meal` et `/generate-meal-plan`.

--- a/app/main.py
+++ b/app/main.py
@@ -6,10 +6,49 @@ from slowapi.middleware import SlowAPIMiddleware
 from app.limiter import limiter
 from app.routers import health, meal_analysis, meal_plan, nutrition_goals
 
+API_DESCRIPTION = """
+Micro-service d'analyse nutritionnelle et de generation de plans repas par IA, partie de la plateforme MSPR HealthAI Coach.
+
+Deux pipelines d'IA sont exposes :
+
+- **Analyse de repas** : photo en entree, classification HuggingFace (`nateraw/food`, modele Food-101), lookup nutritionnel sur les datasets ETL, detection de desequilibres macros vs profil utilisateur, puis recommandations generees par Ollama (Gemma3:4b) avec fallback matrice statique.
+- **Generation de plans repas** : objectif de sante, preferences alimentaires et budget, prompt structure soumis a Ollama, validation du JSON et persistance du plan sur 1 a 30 jours.
+
+Le service expose egalement la gestion du profil nutritionnel (`nutrition-goals/me`) et l'historique pagine des analyses (`meal-analyses/me`). L'authentification se fait via JWT signe par MSPR-AUTH (`Authorization: Bearer <jwt>`).
+"""
+
+TAGS_METADATA = [
+    {
+        "name": "Analyse",
+        "description": "Analyse d'un repas a partir d'une photo : classification HuggingFace, macros et recommandations.",
+    },
+    {
+        "name": "Plans",
+        "description": "Generation de plans repas personnalises via Ollama (avec fallback matrice statique).",
+    },
+    {
+        "name": "Profil",
+        "description": "Gestion du profil nutritionnel de l'utilisateur (objectifs caloriques, macros cibles, allergies, regime).",
+    },
+    {
+        "name": "Historique",
+        "description": "Lecture pagine des analyses passees pour l'utilisateur authentifie.",
+    },
+    {
+        "name": "Sante",
+        "description": "Healthcheck du service et de ses dependances (PostgreSQL, Ollama).",
+    },
+]
+
 app = FastAPI(
-    title="MSPR HealthAI Coach — AI Nutrition",
-    description="Micro-service d'analyse nutritionnelle par IA",
+    title="MSPR HealthAI Coach - AI Nutrition",
+    description=API_DESCRIPTION,
     version="1.0.0",
+    contact={
+        "name": "Arthur Poncin",
+        "email": "arthur.poncin@sixense-group.com",
+    },
+    openapi_tags=TAGS_METADATA,
 )
 
 app.state.limiter = limiter

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ Deux pipelines d'IA sont exposes :
 - **Analyse de repas** : photo en entree, classification HuggingFace (`nateraw/food`, modele Food-101), lookup nutritionnel sur les datasets ETL, detection de desequilibres macros vs profil utilisateur, puis recommandations generees par Ollama (Gemma3:4b) avec fallback matrice statique.
 - **Generation de plans repas** : objectif de sante, preferences alimentaires et budget, prompt structure soumis a Ollama, validation du JSON et persistance du plan sur 1 a 30 jours.
 
-Le service expose egalement la gestion du profil nutritionnel (`nutrition-goals/me`) et l'historique pagine des analyses (`meal-analyses/me`). L'authentification se fait via JWT signe par MSPR-AUTH (`Authorization: Bearer <jwt>`).
+Le service expose egalement la gestion du profil nutritionnel (`nutrition-goals/me`) et l'historique pagine des analyses et des plans (`meal-analyses/me`, `meal-plans/me`). L'authentification se fait via JWT signe par MSPR-AUTH (`Authorization: Bearer <jwt>`).
 """
 
 TAGS_METADATA = [
@@ -32,7 +32,7 @@ TAGS_METADATA = [
     },
     {
         "name": "Historique",
-        "description": "Lecture pagine des analyses passees pour l'utilisateur authentifie.",
+        "description": "Lecture pagine des analyses de repas et des plans generes pour l'utilisateur authentifie.",
     },
     {
         "name": "Sante",

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -18,7 +18,38 @@ async def check_ollama() -> str:
         return "down"
 
 
-@router.get("/health")
+_HEALTH_DESCRIPTION = """
+Verifie l'etat operationnel du service et de ses dependances critiques.
+
+Renvoie un statut global, l'etat individuel de PostgreSQL et d'Ollama, ainsi qu'un horodatage UTC.
+
+- `status` : `ok` si toutes les dependances sont joignables, `degraded` sinon.
+- `postgres` : `up` ou `down` (timeout 3 s sur SELECT 1).
+- `ollama` : `up` ou `down` (timeout 3 s sur GET /api/tags).
+
+Cet endpoint est non authentifie et ne consomme aucune ressource lourde. Il est utilise par les sondes de liveness/readiness Docker et par le monitoring.
+"""
+
+_HEALTH_RESPONSE_EXAMPLE = {
+    "status": "ok",
+    "postgres": "up",
+    "ollama": "up",
+    "timestamp": "2026-04-29T10:15:00.123456+00:00",
+}
+
+
+@router.get(
+    "/health",
+    tags=["Sante"],
+    summary="Healthcheck du service et de ses dependances",
+    description=_HEALTH_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Statut operationnel (ok ou degraded selon les dependances).",
+            "content": {"application/json": {"example": _HEALTH_RESPONSE_EXAMPLE}},
+        },
+    },
+)
 async def health():
     postgres = check_postgres()
     ollama = await check_ollama()

--- a/app/routers/meal_analysis.py
+++ b/app/routers/meal_analysis.py
@@ -24,9 +24,120 @@ def _user_id_from_auth(authorization: str | None) -> int:
         raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
 
 
-@router.post("/analyze-meal")
+_ANALYZE_DESCRIPTION = """
+Analyse une photo de repas et renvoie macros, desequilibres et recommandations.
+
+Pipeline applique :
+
+1. Classification par le modele HuggingFace `nateraw/food` (Food-101, top-3 aliments + confiance).
+2. Lookup nutritionnel sur la table `nutrition_entries` (datasets ETL).
+3. Detection des desequilibres macros (calories, proteines, glucides, lipides) par rapport au profil utilisateur (`nutrition-goals/me`). Si aucun profil n'est configure, l'analyse renvoie quand meme les macros sans recommandations.
+4. Generation des recommandations par Ollama (Gemma3:4b) avec cache 30 jours par hash (top_label, health_goal, imbalances). En cas d'echec LLM, repli sur la matrice statique 16 cas (`fallback: true`).
+5. Persistance dans `meal_analyses` pour consultation via `GET /api/v1/meal-analyses/me`.
+
+**Limitations** : modele entraine sur Food-101 (101 classes occidentales), inference CPU (1-3 s par appel). Pour les recommandations, le LLM peut etre lent (5-15 s sur CPU), prevoir un timeout cote client.
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis (JWT signe par MSPR-AUTH).
+"""
+
+_ANALYZE_SUCCESS_EXAMPLE = {
+    "analysis_id": 137,
+    "detected_foods": [
+        {
+            "label": "pizza",
+            "confidence": 0.85,
+            "nutrition": {
+                "calories": 1300,
+                "protein_g": 30,
+                "carbs_g": 160,
+                "fat_g": 50,
+                "fiber_g": 5,
+            },
+        },
+        {"label": "lasagna", "confidence": 0.07, "nutrition": None},
+    ],
+    "macros": {
+        "calories": 1300,
+        "protein_g": 30,
+        "carbs_g": 160,
+        "fat_g": 50,
+        "fiber_g": 5,
+    },
+    "imbalances": [
+        "Apport calorique eleve (65 % du daily target).",
+        "Glucides au-dessus de la cible journaliere.",
+    ],
+    "recommendations": [
+        "Reduis la portion au prochain repas et privilegie une assiette plus protee.",
+        "Equilibre la journee avec un diner riche en legumes verts.",
+    ],
+    "fallback": False,
+}
+
+
+_HISTORY_DESCRIPTION = """
+Renvoie l'historique pagine des analyses de repas pour l'utilisateur authentifie.
+
+Tri decroissant par date d'analyse. Chaque element contient les aliments detectes, les macros, les recommandations sauvegardees et la date.
+
+Pagination par `limit` (defaut 20, max 100) et `offset` (defaut 0). Le total est inclus dans la reponse pour permettre au client d'afficher un compteur ou de preparer une pagination infinie.
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis. L'historique est strictement scope a l'utilisateur du JWT.
+"""
+
+_HISTORY_RESPONSE_EXAMPLE = {
+    "items": [
+        {
+            "id": 137,
+            "detected_foods": [
+                {
+                    "label": "pizza",
+                    "confidence": 0.85,
+                    "nutrition": {
+                        "calories": 1300,
+                        "protein_g": 30,
+                        "carbs_g": 160,
+                        "fat_g": 50,
+                    },
+                }
+            ],
+            "macros": {
+                "calories": 1300,
+                "protein_g": 30,
+                "carbs_g": 160,
+                "fat_g": 50,
+                "fiber_g": 5,
+            },
+            "recommendations": ["Reduis la portion au prochain repas."],
+            "created_at": "2026-04-29T10:15:00",
+        }
+    ],
+    "total": 137,
+    "limit": 20,
+    "offset": 0,
+}
+
+
+@router.post(
+    "/analyze-meal",
+    tags=["Analyse"],
+    summary="Analyse une photo de repas (macros + recommandations IA)",
+    description=_ANALYZE_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Analyse reussie : macros, desequilibres et recommandations.",
+            "content": {"application/json": {"example": _ANALYZE_SUCCESS_EXAMPLE}},
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+        413: {"description": "Image trop volumineuse (limite 10 Mo)."},
+        415: {"description": "Type MIME non supporte (utiliser JPEG, PNG ou WebP)."},
+        422: {"description": "Image illisible, corrompue ou aucun aliment detecte."},
+    },
+)
 async def analyze_meal(
-    photo: UploadFile = File(...),
+    photo: UploadFile = File(
+        ..., description="Photo du repas (JPEG, PNG ou WebP, 10 Mo max)."
+    ),
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ):
@@ -37,13 +148,28 @@ async def analyze_meal(
         )
     image_bytes = await photo.read()
     if len(image_bytes) > _MAX_SIZE:
-        raise HTTPException(status_code=413, detail="Image trop volumineuse (max 10 Mo).")
+        raise HTTPException(
+            status_code=413, detail="Image trop volumineuse (max 10 Mo)."
+        )
 
     user_id = _user_id_from_auth(authorization)
     return await orchestrate(image_bytes, user_id, db)
 
 
-@router.get("/meal-analyses/me", response_model=PaginatedAnalysesResponse)
+@router.get(
+    "/meal-analyses/me",
+    response_model=PaginatedAnalysesResponse,
+    tags=["Historique"],
+    summary="Historique pagine des analyses de l'utilisateur",
+    description=_HISTORY_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Liste pagine d'analyses (tri decroissant sur created_at).",
+            "content": {"application/json": {"example": _HISTORY_RESPONSE_EXAMPLE}},
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+    },
+)
 def list_my_meal_analyses(
     authorization: str | None = Header(default=None),
     limit: int = Query(default=20, ge=1, le=100),

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -11,7 +11,7 @@ from app.services import jwt_decoder, meal_plan_history, meal_plan_orchestrator
 # l'inspection. Avec l'import differe, MealPlanRequest reste un ForwardRef et
 # le decodage du body echoue (PydanticUserError "class-not-fully-defined").
 
-router = APIRouter(tags=["meal-plan"])
+router = APIRouter()
 
 
 def _auth(authorization: str | None) -> tuple[int, str]:
@@ -26,11 +26,104 @@ def _auth(authorization: str | None) -> tuple[int, str]:
     return user_id, token
 
 
-@router.post("/generate-meal-plan", response_model=MealPlanResponse)
+_PLAN_DESCRIPTION = """
+Genere un plan repas personnalise sur 1 a 30 jours en fonction de l'objectif sante, du regime, des allergies et du budget.
+
+Pipeline applique :
+
+1. Resolution de l'objectif sante : valeur explicite > profil utilisateur (`nutrition-goals/me`) > `balance` par defaut.
+2. Lecture des entitlements (tier utilisateur via MSPR-AUTH). Les tiers `premium` et `premium_plus` bypassent le cache et regenerent systematiquement.
+3. Cache contenu : hash canonique des inputs (objectif, regime, allergies triees, budget, calories cible, duree). Cache hit, on renvoie le plan stocke.
+4. Cache miss : appel Ollama (Gemma3:4b) avec prompt structure et `format: json`. En cas d'echec ou JSON invalide, repli sur la matrice 16 plans statiques (`fallback: true`).
+5. Persistance dans `meal_plans` et renvoi du plan complet.
+
+**Rate limit** : 10 requetes par heure et 3 par minute par utilisateur (header standard `Retry-After` en cas de depassement).
+
+**Latence** : 5-30 s sur CPU pour une generation LLM. Cache hit < 100 ms.
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis. Le JWT est aussi propage a MSPR-AUTH pour resoudre les entitlements.
+"""
+
+_PLAN_REQUEST_EXAMPLES = {
+    "muscle_gain_omnivore": {
+        "summary": "Prise de masse, omnivore, 7 jours",
+        "value": {
+            "health_goal": "muscle_gain",
+            "diet_type": "omnivore",
+            "duration_days": 7,
+            "allergies": [],
+            "budget_eur_per_day": 15.0,
+        },
+    },
+    "weight_loss_vegetarien": {
+        "summary": "Perte de poids, vegetarien, 14 jours",
+        "value": {
+            "health_goal": "weight_loss",
+            "diet_type": "vegetarien",
+            "duration_days": 14,
+            "allergies": ["arachides"],
+            "budget_eur_per_day": 10.0,
+        },
+    },
+    "balance_vegan_minimum": {
+        "summary": "Equilibre, vegan, requete minimale (1 jour, sans budget)",
+        "value": {"diet_type": "vegan", "duration_days": 1},
+    },
+}
+
+_PLAN_RESPONSE_EXAMPLE = {
+    "plan_id": 42,
+    "fallback": False,
+    "days": [
+        {
+            "day": 1,
+            "meals": [
+                {
+                    "name": "Bowl quinoa, poulet et legumes verts",
+                    "macros": {
+                        "calories": 620,
+                        "protein_g": 45.0,
+                        "carbs_g": 65.0,
+                        "fat_g": 18.0,
+                    },
+                    "ingredients": [
+                        "100 g quinoa",
+                        "150 g blanc de poulet",
+                        "200 g brocolis",
+                        "1 c.s. huile d'olive",
+                    ],
+                    "est_budget_eur": 5.5,
+                    "prep_time_min": 25,
+                }
+            ],
+        }
+    ],
+}
+
+
+@router.post(
+    "/generate-meal-plan",
+    response_model=MealPlanResponse,
+    tags=["Plans"],
+    summary="Genere un plan repas personnalise (1 a 30 jours)",
+    description=_PLAN_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Plan repas genere ou recupere du cache. `fallback: true` indique un repli matrice statique.",
+            "content": {"application/json": {"example": _PLAN_RESPONSE_EXAMPLE}},
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+        422: {
+            "description": "Payload invalide (regime inconnu, duree hors [1, 30], etc)."
+        },
+        429: {"description": "Rate limit depasse (10/heure ou 3/minute)."},
+        503: {"description": "Ollama injoignable et fallback statique indisponible."},
+    },
+)
 @limiter.limit("10/hour;3/minute")
 async def generate_meal_plan(
     request: Request,  # requis par SlowAPI pour key_func
-    payload: MealPlanRequest,
+    payload: MealPlanRequest = Body(..., openapi_examples=_PLAN_REQUEST_EXAMPLES),
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ) -> MealPlanResponse:
@@ -38,7 +131,77 @@ async def generate_meal_plan(
     return await meal_plan_orchestrator.generate(user_id, payload, token, db)
 
 
-@router.get("/meal-plans/me", response_model=PaginatedPlansResponse)
+_PLANS_HISTORY_DESCRIPTION = """
+Renvoie l'historique pagine des plans repas generes pour l'utilisateur authentifie.
+
+Tri decroissant par date de generation. Chaque element contient l'objectif sante, les contraintes (regime, allergies, budget, duree, calories cible) et le plan complet (jours et repas).
+
+Pagination par `limit` (defaut 20, max 100) et `offset` (defaut 0). Le total est inclus dans la reponse pour permettre au client d'afficher un compteur ou de preparer une pagination infinie.
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis. L'historique est strictement scope a l'utilisateur du JWT.
+"""
+
+_PLANS_HISTORY_RESPONSE_EXAMPLE = {
+    "items": [
+        {
+            "id": 42,
+            "objective": "muscle_gain",
+            "constraints": {
+                "diet_type": "omnivore",
+                "allergies": ["arachides"],
+                "duration_days": 7,
+                "budget_per_day": 15.0,
+            },
+            "plan": {
+                "fallback": False,
+                "days": [
+                    {
+                        "day": 1,
+                        "meals": [
+                            {
+                                "name": "Bowl quinoa, poulet et legumes verts",
+                                "macros": {
+                                    "calories": 620,
+                                    "protein_g": 45.0,
+                                    "carbs_g": 65.0,
+                                    "fat_g": 18.0,
+                                },
+                                "ingredients": [
+                                    "100 g quinoa",
+                                    "150 g blanc de poulet",
+                                ],
+                                "est_budget_eur": 5.5,
+                                "prep_time_min": 25,
+                            }
+                        ],
+                    }
+                ],
+            },
+            "generated_at": "2026-04-29T10:15:00",
+        }
+    ],
+    "total": 12,
+    "limit": 20,
+    "offset": 0,
+}
+
+
+@router.get(
+    "/meal-plans/me",
+    response_model=PaginatedPlansResponse,
+    tags=["Historique"],
+    summary="Historique pagine des plans repas de l'utilisateur",
+    description=_PLANS_HISTORY_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Liste pagine de plans repas (tri decroissant sur generated_at).",
+            "content": {
+                "application/json": {"example": _PLANS_HISTORY_RESPONSE_EXAMPLE}
+            },
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+    },
+)
 def list_my_meal_plans(
     authorization: str | None = Header(default=None),
     limit: int = Query(default=20, ge=1, le=100),

--- a/app/routers/nutrition_goals.py
+++ b/app/routers/nutrition_goals.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Body, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.schemas import NutritionGoalRequest, NutritionGoalResponse
 from app.services import jwt_decoder, profile_service
 
-router = APIRouter(prefix="/nutrition-goals", tags=["nutrition-goals"])
+router = APIRouter(prefix="/nutrition-goals")
 
 
 def _user_id_from_auth(authorization: str | None) -> int:
@@ -20,7 +20,86 @@ def _user_id_from_auth(authorization: str | None) -> int:
         raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
 
 
-@router.get("/me", response_model=NutritionGoalResponse)
+_GET_DESCRIPTION = """
+Renvoie le profil nutritionnel de l'utilisateur authentifie.
+
+Le profil regroupe l'objectif sante (`weight_loss`, `muscle_gain`, `balance`, `sport_performance`), les cibles caloriques et macros, les allergies declarees et le regime (`omnivore`, `vegetarien`, `vegan`, `sans_gluten`).
+
+Renvoie 404 si aucun profil n'a encore ete configure (un PUT initial est alors necessaire).
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis. Le profil est strictement scope a l'utilisateur du JWT.
+"""
+
+_PUT_DESCRIPTION = """
+Cree ou met a jour le profil nutritionnel de l'utilisateur authentifie (upsert).
+
+Tous les champs sont optionnels : un PUT partiel ecrase la ligne avec la valeur fournie. Pour conserver une valeur existante, le client doit la renvoyer explicitement.
+
+Les valeurs sont utilisees ensuite par `/analyze-meal` (detection des desequilibres) et `/generate-meal-plan` (resolution de l'objectif sante par defaut).
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis.
+"""
+
+_GOAL_RESPONSE_EXAMPLE = {
+    "user_id": 42,
+    "health_goal": "muscle_gain",
+    "calories_target": 2400,
+    "protein_g": "140.0",
+    "carbs_g": "260.0",
+    "fat_g": "80.0",
+    "allergies": ["arachides", "fruits a coque"],
+    "diet_type": "omnivore",
+}
+
+_GOAL_REQUEST_EXAMPLES = {
+    "muscle_gain": {
+        "summary": "Prise de masse, omnivore",
+        "value": {
+            "health_goal": "muscle_gain",
+            "calories_target": 2400,
+            "protein_g": 140,
+            "carbs_g": 260,
+            "fat_g": 80,
+            "allergies": ["arachides"],
+            "diet_type": "omnivore",
+        },
+    },
+    "weight_loss_vegetarien": {
+        "summary": "Perte de poids, vegetarien",
+        "value": {
+            "health_goal": "weight_loss",
+            "calories_target": 1700,
+            "protein_g": 90,
+            "carbs_g": 170,
+            "fat_g": 55,
+            "allergies": [],
+            "diet_type": "vegetarien",
+        },
+    },
+    "minimal": {
+        "summary": "Profil minimal (objectif sante seul)",
+        "value": {"health_goal": "balance"},
+    },
+}
+
+
+@router.get(
+    "/me",
+    response_model=NutritionGoalResponse,
+    tags=["Profil"],
+    summary="Recupere le profil nutritionnel de l'utilisateur",
+    description=_GET_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Profil nutritionnel courant.",
+            "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+        404: {
+            "description": "Aucun profil nutritionnel configure (faire un PUT initial)."
+        },
+    },
+)
 def get_my_profile(
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
@@ -28,13 +107,31 @@ def get_my_profile(
     user_id = _user_id_from_auth(authorization)
     profile = profile_service.get_profile(user_id, db)
     if profile is None:
-        raise HTTPException(status_code=404, detail="Profil nutritionnel non configure.")
+        raise HTTPException(
+            status_code=404, detail="Profil nutritionnel non configure."
+        )
     return NutritionGoalResponse.model_validate(profile)
 
 
-@router.put("/me", response_model=NutritionGoalResponse)
+@router.put(
+    "/me",
+    response_model=NutritionGoalResponse,
+    tags=["Profil"],
+    summary="Cree ou met a jour le profil nutritionnel (upsert)",
+    description=_PUT_DESCRIPTION,
+    responses={
+        200: {
+            "description": "Profil mis a jour (ou cree).",
+            "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+        },
+        401: {"description": "JWT manquant, malforme ou invalide."},
+        422: {
+            "description": "Payload invalide (objectif sante inconnu, valeurs non numeriques, etc)."
+        },
+    },
+)
 def upsert_my_profile(
-    payload: NutritionGoalRequest,
+    payload: NutritionGoalRequest = Body(..., openapi_examples=_GOAL_REQUEST_EXAMPLES),
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ) -> NutritionGoalResponse:

--- a/tests/test_openapi_doc.py
+++ b/tests/test_openapi_doc.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+VALID_TAGS = {"Analyse", "Plans", "Profil", "Historique", "Sante"}
+
+# (path, method, expected_tag, expected_error_codes)
+EXPECTED_OPERATIONS: list[tuple[str, str, str, set[str]]] = [
+    ("/health", "get", "Sante", set()),
+    ("/api/v1/analyze-meal", "post", "Analyse", {"401", "413", "415", "422"}),
+    ("/api/v1/meal-analyses/me", "get", "Historique", {"401"}),
+    ("/api/v1/meal-plans/me", "get", "Historique", {"401"}),
+    ("/api/v1/generate-meal-plan", "post", "Plans", {"401", "422", "429"}),
+    ("/api/v1/nutrition-goals/me", "get", "Profil", {"401", "404"}),
+    ("/api/v1/nutrition-goals/me", "put", "Profil", {"401", "422"}),
+]
+
+
+@pytest.fixture(scope="module")
+def openapi_schema() -> dict[str, Any]:
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.parametrize("path", ["/docs", "/redoc"])
+def test_swagger_and_redoc_render(path: str) -> None:
+    response = TestClient(app).get(path)
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert b"<html" in response.content.lower()
+
+
+def test_app_has_global_metadata(openapi_schema: dict[str, Any]) -> None:
+    info = openapi_schema["info"]
+    assert info["title"]
+    assert info.get("version")
+    assert info.get("description")
+    assert len(info["description"]) >= 80, "description globale trop courte"
+    assert info.get("contact"), "info.contact manquant"
+
+
+def test_app_declares_all_business_tags(openapi_schema: dict[str, Any]) -> None:
+    declared = {tag["name"] for tag in openapi_schema.get("tags", [])}
+    missing = VALID_TAGS - declared
+    assert not missing, f"tags non declares dans tags_metadata : {missing}"
+    for tag in openapi_schema.get("tags", []):
+        if tag["name"] in VALID_TAGS:
+            assert tag.get("description"), f"tag {tag['name']} sans description"
+
+
+@pytest.mark.parametrize(
+    "path,method,expected_tag,expected_errors",
+    EXPECTED_OPERATIONS,
+    ids=[f"{m.upper()} {p}" for p, m, _, _ in EXPECTED_OPERATIONS],
+)
+def test_operation_is_richly_documented(
+    openapi_schema: dict[str, Any],
+    path: str,
+    method: str,
+    expected_tag: str,
+    expected_errors: set[str],
+) -> None:
+    paths = openapi_schema["paths"]
+    assert path in paths, f"path absent du schema OpenAPI : {path}"
+    assert method in paths[path], f"methode {method} absente sur {path}"
+    op = paths[path][method]
+
+    assert op.get("summary"), f"{method.upper()} {path} : summary manquant"
+    description = op.get("description") or ""
+    assert (
+        len(description) >= 80
+    ), f"{method.upper()} {path} : description trop courte ({len(description)} chars)"
+
+    tags = op.get("tags") or []
+    assert tags, f"{method.upper()} {path} : aucun tag"
+    assert (
+        tags[0] in VALID_TAGS
+    ), f"{method.upper()} {path} : tag {tags[0]} hors whitelist"
+    assert (
+        tags[0] == expected_tag
+    ), f"{method.upper()} {path} : tag {tags[0]} != {expected_tag} attendu"
+
+    responses = op.get("responses") or {}
+    success_codes = {code for code in responses if code.startswith("2")}
+    assert success_codes, f"{method.upper()} {path} : aucune reponse 2xx documentee"
+
+    missing_errors = expected_errors - set(responses)
+    assert (
+        not missing_errors
+    ), f"{method.upper()} {path} : codes d'erreur manquants {missing_errors}"


### PR DESCRIPTION
## Summary

- `app/main.py` : title, description longue, version, contact, `openapi_tags` avec les 5 tags francais (Analyse, Plans, Profil, Historique, Sante).
- 6 endpoints enrichis : summary, description riche, examples request/response, codes d'erreur 401/404/413/415/422/429/503 documentes.
- README reecrit : intro, architecture (Mermaid), stack, demarrage, env vars, table endpoints, tests, metriques, limitations, liens vers PRD #15, `docs/metrics.md`, `data_model.md` MSPR-DB.
- `tests/test_openapi_doc.py` : verifie metadonnees globales, declarations de tags, et pour chaque operation summary / description / tag / responses + smoke test rendu `/docs` et `/redoc`.

## Test plan

- [x] `docker compose --profile test run --rm tests` : 233 passed, coverage 96 %
- [x] `ruff check app tests` clean
- [x] Pas de tirets cadratins dans le code, les commentaires ou le README
- [ ] Ouvrir `/docs` et `/redoc` en local et verifier le rendu visuel des examples

Closes #30