### PR TITLE
[Slice 4] Module portion_sizes (mapping Food-101 vers PNNS + serving sizes)

### DIFF
--- a/app/data/portion_sizes.py
+++ b/app/data/portion_sizes.py
@@ -179,5 +179,7 @@ _FOOD101_TO_PNNS_CATEGORY: dict[str, str] = {
 def get_serving_sizes(food_label: str) -> list[ServingSize]:
     category = _FOOD101_TO_PNNS_CATEGORY.get(food_label)
     if category is None:
-        return [ServingSize(label=ServingSizeLabel.medium, grams=100)]
-    return _PNNS_SERVING_SIZES[category]
+        return [
+            ServingSize(label=ServingSizeLabel.medium, grams=100, description="100 g")
+        ]
+    return list(_PNNS_SERVING_SIZES[category])

--- a/app/data/portion_sizes.py
+++ b/app/data/portion_sizes.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from app.models.schemas import ServingSize, ServingSizeLabel
+
+# Grammages PNNS (Programme National Nutrition Sante) issus des reperes
+# mangerbouger.fr et ANSES (PNNS 4, table CIQUAL). 3 tailles indicatives par
+# categorie : small (portion modeste), medium (portion de reference adulte),
+# large (portion genereuse / sportif).
+_PNNS_SERVING_SIZES: dict[str, list[ServingSize]] = {
+    "legumes": [
+        ServingSize(label=ServingSizeLabel.small, grams=80, description="80 g cuit"),
+        ServingSize(label=ServingSizeLabel.medium, grams=200, description="200 g cuit"),
+        ServingSize(label=ServingSizeLabel.large, grams=300, description="300 g cuit"),
+    ],
+    "feculents": [
+        ServingSize(label=ServingSizeLabel.small, grams=100, description="100 g cuit"),
+        ServingSize(label=ServingSizeLabel.medium, grams=200, description="200 g cuit"),
+        ServingSize(label=ServingSizeLabel.large, grams=300, description="300 g cuit"),
+    ],
+    "viandes": [
+        ServingSize(label=ServingSizeLabel.small, grams=70, description="70 g cuit"),
+        ServingSize(label=ServingSizeLabel.medium, grams=100, description="100 g cuit"),
+        ServingSize(label=ServingSizeLabel.large, grams=150, description="150 g cuit"),
+    ],
+    "poissons": [
+        ServingSize(label=ServingSizeLabel.small, grams=70, description="70 g cuit"),
+        ServingSize(label=ServingSizeLabel.medium, grams=100, description="100 g cuit"),
+        ServingSize(label=ServingSizeLabel.large, grams=150, description="150 g cuit"),
+    ],
+    "fromages": [
+        ServingSize(label=ServingSizeLabel.small, grams=20, description="20 g"),
+        ServingSize(
+            label=ServingSizeLabel.medium, grams=30, description="30 g (une portion)"
+        ),
+        ServingSize(label=ServingSizeLabel.large, grams=40, description="40 g"),
+    ],
+    "fruits": [
+        ServingSize(label=ServingSizeLabel.small, grams=80, description="80 g cru"),
+        ServingSize(
+            label=ServingSizeLabel.medium, grams=150, description="150 g cru (un fruit)"
+        ),
+        ServingSize(label=ServingSizeLabel.large, grams=200, description="200 g cru"),
+    ],
+    "oleagineux": [
+        ServingSize(
+            label=ServingSizeLabel.small, grams=15, description="15 g (une poignee)"
+        ),
+        ServingSize(label=ServingSizeLabel.medium, grams=30, description="30 g"),
+        ServingSize(label=ServingSizeLabel.large, grams=50, description="50 g"),
+    ],
+    "plats_composes": [
+        ServingSize(label=ServingSizeLabel.small, grams=200, description="200 g"),
+        ServingSize(label=ServingSizeLabel.medium, grams=350, description="350 g"),
+        ServingSize(label=ServingSizeLabel.large, grams=500, description="500 g"),
+    ],
+    "desserts": [
+        ServingSize(label=ServingSizeLabel.small, grams=50, description="50 g"),
+        ServingSize(label=ServingSizeLabel.medium, grams=100, description="100 g"),
+        ServingSize(label=ServingSizeLabel.large, grams=150, description="150 g"),
+    ],
+    "boissons": [
+        ServingSize(label=ServingSizeLabel.small, grams=150, description="150 ml"),
+        ServingSize(
+            label=ServingSizeLabel.medium, grams=250, description="250 ml (un verre)"
+        ),
+        ServingSize(label=ServingSizeLabel.large, grams=350, description="350 ml"),
+    ],
+}
+
+# Mapping HITL des 101 labels Food-101 vers les 10 categories PNNS.
+# Pre-genere puis revu manuellement ligne par ligne (cf. issue NUT-49).
+# Toute modification requiert une nouvelle validation humaine et la mise a
+# jour du snapshot dans tests/unit/test_portion_sizes.py.
+_FOOD101_TO_PNNS_CATEGORY: dict[str, str] = {
+    "apple_pie": "desserts",
+    "baby_back_ribs": "viandes",
+    "baklava": "desserts",
+    "beef_carpaccio": "viandes",
+    "beef_tartare": "viandes",
+    "beet_salad": "legumes",
+    "beignets": "desserts",
+    "bibimbap": "plats_composes",
+    "bread_pudding": "desserts",
+    "breakfast_burrito": "plats_composes",
+    "bruschetta": "plats_composes",
+    "caesar_salad": "legumes",
+    "cannoli": "desserts",
+    "caprese_salad": "legumes",
+    "carrot_cake": "desserts",
+    "ceviche": "poissons",
+    "cheese_plate": "fromages",
+    "cheesecake": "desserts",
+    "chicken_curry": "plats_composes",
+    "chicken_quesadilla": "plats_composes",
+    "chicken_wings": "viandes",
+    "chocolate_cake": "desserts",
+    "chocolate_mousse": "desserts",
+    "churros": "desserts",
+    "clam_chowder": "plats_composes",
+    "club_sandwich": "plats_composes",
+    "crab_cakes": "poissons",
+    "creme_brulee": "desserts",
+    "croque_madame": "plats_composes",
+    "cup_cakes": "desserts",
+    "deviled_eggs": "plats_composes",
+    "donuts": "desserts",
+    "dumplings": "plats_composes",
+    "edamame": "legumes",
+    "eggs_benedict": "plats_composes",
+    "escargots": "plats_composes",
+    "falafel": "plats_composes",
+    "filet_mignon": "viandes",
+    "fish_and_chips": "plats_composes",
+    "foie_gras": "viandes",
+    "french_fries": "feculents",
+    "french_onion_soup": "plats_composes",
+    "french_toast": "plats_composes",
+    "fried_calamari": "poissons",
+    "fried_rice": "feculents",
+    "frozen_yogurt": "desserts",
+    "garlic_bread": "feculents",
+    "gnocchi": "feculents",
+    "greek_salad": "legumes",
+    "grilled_cheese_sandwich": "plats_composes",
+    "grilled_salmon": "poissons",
+    "guacamole": "legumes",
+    "gyoza": "plats_composes",
+    "hamburger": "plats_composes",
+    "hot_and_sour_soup": "plats_composes",
+    "hot_dog": "plats_composes",
+    "huevos_rancheros": "plats_composes",
+    "hummus": "legumes",
+    "ice_cream": "desserts",
+    "lasagna": "plats_composes",
+    "lobster_bisque": "plats_composes",
+    "lobster_roll_sandwich": "plats_composes",
+    "macaroni_and_cheese": "plats_composes",
+    "macarons": "desserts",
+    "miso_soup": "plats_composes",
+    "mussels": "poissons",
+    "nachos": "plats_composes",
+    "omelette": "plats_composes",
+    "onion_rings": "legumes",
+    "oysters": "poissons",
+    "pad_thai": "plats_composes",
+    "paella": "plats_composes",
+    "pancakes": "desserts",
+    "panna_cotta": "desserts",
+    "peking_duck": "viandes",
+    "pho": "plats_composes",
+    "pizza": "plats_composes",
+    "pork_chop": "viandes",
+    "poutine": "plats_composes",
+    "prime_rib": "viandes",
+    "pulled_pork_sandwich": "plats_composes",
+    "ramen": "plats_composes",
+    "ravioli": "plats_composes",
+    "red_velvet_cake": "desserts",
+    "risotto": "feculents",
+    "samosa": "plats_composes",
+    "sashimi": "poissons",
+    "scallops": "poissons",
+    "seaweed_salad": "legumes",
+    "shrimp_and_grits": "plats_composes",
+    "spaghetti_bolognese": "plats_composes",
+    "spaghetti_carbonara": "plats_composes",
+    "spring_rolls": "plats_composes",
+    "steak": "viandes",
+    "strawberry_shortcake": "desserts",
+    "sushi": "plats_composes",
+    "tacos": "plats_composes",
+    "takoyaki": "plats_composes",
+    "tiramisu": "desserts",
+    "tuna_tartare": "poissons",
+    "waffles": "desserts",
+}
+
+
+def get_serving_sizes(food_label: str) -> list[ServingSize]:
+    category = _FOOD101_TO_PNNS_CATEGORY.get(food_label)
+    if category is None:
+        return [ServingSize(label=ServingSizeLabel.medium, grams=100)]
+    return _PNNS_SERVING_SIZES[category]

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -17,6 +17,7 @@ class HealthGoal(str, Enum):
 
 # MealAnalysis
 
+
 class MealAnalysisItem(BaseModel):
     id: int
     detected_foods: list[dict[str, Any]]
@@ -42,7 +43,12 @@ class PaginatedAnalysesResponse(BaseModel):
                         "detected_foods": [
                             {"label": "pizza", "confidence": 0.85, "nutrition": {}}
                         ],
-                        "macros": {"calories": 1300, "protein_g": 30, "carbs_g": 160, "fat_g": 50},
+                        "macros": {
+                            "calories": 1300,
+                            "protein_g": 30,
+                            "carbs_g": 160,
+                            "fat_g": 50,
+                        },
                         "recommendations": ["Reduis la portion au prochain repas."],
                         "created_at": "2026-04-29T10:15:00",
                     }
@@ -56,6 +62,7 @@ class PaginatedAnalysesResponse(BaseModel):
 
 
 # NutritionGoal
+
 
 class NutritionGoalRequest(BaseModel):
     health_goal: HealthGoal | None = None
@@ -74,6 +81,7 @@ class NutritionGoalResponse(NutritionGoalRequest):
 
 
 # Plans repas fallback (issue NUT-8). Cf. POST /api/v1/generate-meal-plan.
+
 
 class MealMacros(BaseModel):
     calories: int
@@ -197,3 +205,18 @@ class RecommendationContext(BaseModel):
     user_id: int
     imbalance: Imbalance
     health_goal: HealthGoal
+
+
+# Tailles de portion PNNS (issue NUT-49). Cf. app/data/portion_sizes.py.
+
+
+class ServingSizeLabel(str, Enum):
+    small = "small"
+    medium = "medium"
+    large = "large"
+
+
+class ServingSize(BaseModel):
+    label: ServingSizeLabel
+    grams: int = Field(gt=0)
+    description: str | None = None

--- a/tests/unit/test_portion_sizes.py
+++ b/tests/unit/test_portion_sizes.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import pytest
+
+from app.data.portion_sizes import (
+    _FOOD101_TO_PNNS_CATEGORY,
+    _PNNS_SERVING_SIZES,
+    get_serving_sizes,
+)
+from app.models.schemas import ServingSize
+
+
+def test_known_label_returns_three_portions_small_medium_large() -> None:
+    portions = get_serving_sizes("pizza")
+
+    assert len(portions) == 3
+    assert {p.label for p in portions} == {"small", "medium", "large"}
+    assert all(isinstance(p, ServingSize) for p in portions)
+    assert all(p.grams > 0 for p in portions)
+
+
+def test_unknown_label_returns_medium_100g_fallback() -> None:
+    portions = get_serving_sizes("not_a_real_food_label")
+
+    assert len(portions) == 1
+    assert portions[0].label == "medium"
+    assert portions[0].grams == 100
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        "legumes",
+        "feculents",
+        "viandes",
+        "poissons",
+        "fromages",
+        "fruits",
+        "oleagineux",
+        "plats_composes",
+        "desserts",
+        "boissons",
+    ],
+)
+def test_each_pnns_category_has_three_ordered_portions(category: str) -> None:
+    portions = _PNNS_SERVING_SIZES[category]
+
+    assert [p.label for p in portions] == ["small", "medium", "large"]
+    assert portions[0].grams < portions[1].grams < portions[2].grams
+
+
+def test_mapping_has_exactly_101_entries() -> None:
+    assert len(_FOOD101_TO_PNNS_CATEGORY) == 101
+
+
+def test_mapping_only_uses_declared_pnns_categories() -> None:
+    declared = set(_PNNS_SERVING_SIZES.keys())
+    used = set(_FOOD101_TO_PNNS_CATEGORY.values())
+
+    assert used <= declared, f"unknown categories: {used - declared}"
+
+
+# Snapshot HITL : tout changement ici doit etre revu manuellement (cf. issue #49).
+# Ne JAMAIS regenerer automatiquement ce dict, c'est un garde-fou contre
+# les regressions de mapping Food-101 -> PNNS.
+EXPECTED_MAPPING: dict[str, str] = {
+    "apple_pie": "desserts",
+    "baby_back_ribs": "viandes",
+    "baklava": "desserts",
+    "beef_carpaccio": "viandes",
+    "beef_tartare": "viandes",
+    "beet_salad": "legumes",
+    "beignets": "desserts",
+    "bibimbap": "plats_composes",
+    "bread_pudding": "desserts",
+    "breakfast_burrito": "plats_composes",
+    "bruschetta": "plats_composes",
+    "caesar_salad": "legumes",
+    "cannoli": "desserts",
+    "caprese_salad": "legumes",
+    "carrot_cake": "desserts",
+    "ceviche": "poissons",
+    "cheese_plate": "fromages",
+    "cheesecake": "desserts",
+    "chicken_curry": "plats_composes",
+    "chicken_quesadilla": "plats_composes",
+    "chicken_wings": "viandes",
+    "chocolate_cake": "desserts",
+    "chocolate_mousse": "desserts",
+    "churros": "desserts",
+    "clam_chowder": "plats_composes",
+    "club_sandwich": "plats_composes",
+    "crab_cakes": "poissons",
+    "creme_brulee": "desserts",
+    "croque_madame": "plats_composes",
+    "cup_cakes": "desserts",
+    "deviled_eggs": "plats_composes",
+    "donuts": "desserts",
+    "dumplings": "plats_composes",
+    "edamame": "legumes",
+    "eggs_benedict": "plats_composes",
+    "escargots": "plats_composes",
+    "falafel": "plats_composes",
+    "filet_mignon": "viandes",
+    "fish_and_chips": "plats_composes",
+    "foie_gras": "viandes",
+    "french_fries": "feculents",
+    "french_onion_soup": "plats_composes",
+    "french_toast": "plats_composes",
+    "fried_calamari": "poissons",
+    "fried_rice": "feculents",
+    "frozen_yogurt": "desserts",
+    "garlic_bread": "feculents",
+    "gnocchi": "feculents",
+    "greek_salad": "legumes",
+    "grilled_cheese_sandwich": "plats_composes",
+    "grilled_salmon": "poissons",
+    "guacamole": "legumes",
+    "gyoza": "plats_composes",
+    "hamburger": "plats_composes",
+    "hot_and_sour_soup": "plats_composes",
+    "hot_dog": "plats_composes",
+    "huevos_rancheros": "plats_composes",
+    "hummus": "legumes",
+    "ice_cream": "desserts",
+    "lasagna": "plats_composes",
+    "lobster_bisque": "plats_composes",
+    "lobster_roll_sandwich": "plats_composes",
+    "macaroni_and_cheese": "plats_composes",
+    "macarons": "desserts",
+    "miso_soup": "plats_composes",
+    "mussels": "poissons",
+    "nachos": "plats_composes",
+    "omelette": "plats_composes",
+    "onion_rings": "legumes",
+    "oysters": "poissons",
+    "pad_thai": "plats_composes",
+    "paella": "plats_composes",
+    "pancakes": "desserts",
+    "panna_cotta": "desserts",
+    "peking_duck": "viandes",
+    "pho": "plats_composes",
+    "pizza": "plats_composes",
+    "pork_chop": "viandes",
+    "poutine": "plats_composes",
+    "prime_rib": "viandes",
+    "pulled_pork_sandwich": "plats_composes",
+    "ramen": "plats_composes",
+    "ravioli": "plats_composes",
+    "red_velvet_cake": "desserts",
+    "risotto": "feculents",
+    "samosa": "plats_composes",
+    "sashimi": "poissons",
+    "scallops": "poissons",
+    "seaweed_salad": "legumes",
+    "shrimp_and_grits": "plats_composes",
+    "spaghetti_bolognese": "plats_composes",
+    "spaghetti_carbonara": "plats_composes",
+    "spring_rolls": "plats_composes",
+    "steak": "viandes",
+    "strawberry_shortcake": "desserts",
+    "sushi": "plats_composes",
+    "tacos": "plats_composes",
+    "takoyaki": "plats_composes",
+    "tiramisu": "desserts",
+    "tuna_tartare": "poissons",
+    "waffles": "desserts",
+}
+
+
+def test_food101_mapping_matches_validated_snapshot() -> None:
+    assert _FOOD101_TO_PNNS_CATEGORY == EXPECTED_MAPPING
+
+
+def test_known_steak_label_returns_viandes_portions() -> None:
+    portions = get_serving_sizes("steak")
+
+    grams_by_label = {p.label.value: p.grams for p in portions}
+    assert grams_by_label == {"small": 70, "medium": 100, "large": 150}


### PR DESCRIPTION
Closes #49

## Summary
- Nouveau module `app/data/portion_sizes.py` : mapping HITL des 101 labels Food-101 vers 10 categories PNNS, avec 3 tailles de portion (small/medium/large) par categorie. Grammages PNNS issus de mangerbouger.fr / ANSES.
- API `get_serving_sizes(food_label)` renvoie les 3 portions de la categorie ; fallback `[medium 100 g]` pour tout label inconnu.
- Schemas Pydantic `ServingSize` + `ServingSizeLabel` ajoutes a `app/models/schemas.py`.
- Module non encore branche dans le pipeline (integration prevue en Slice 8).

## Test plan
- [x] `pytest tests/unit/test_portion_sizes.py` : 16 tests passent (lookup connu / inconnu, ordre des grammages, snapshot 101 entrees, garde-fou categories declarees).
- [x] `ruff check` + `ruff format --check` clean sur les fichiers touches.
- [ ] Re-revue manuelle du mapping `_FOOD101_TO_PNNS_CATEGORY` (HITL) avant integration en Slice 8.
- [ ] Verification croisee des grammages PNNS si PNNS 5 publie de nouvelles valeurs.