### PR TITLE
[Slice 3] Module constraint_validator (allergies + budget + regime)

### DIFF
--- a/app/services/constraint_validator.py
+++ b/app/services/constraint_validator.py
@@ -114,18 +114,20 @@ def _normalize(text_value: str) -> str:
     return stripped.casefold()
 
 
-def _ingredient_contains_term(ingredient: str, term: str) -> bool:
-    """Match a frontiere de mot, evite 'lait' dans 'laitue' ou 'oeuf' dans 'boeuf'."""
-    pattern = re.compile(rf"\b{re.escape(_normalize(term))}\b")
-    return bool(pattern.search(_normalize(ingredient)))
+def _compile_term(term: str) -> re.Pattern[str]:
+    """Pattern a frontiere de mot, evite 'lait' dans 'laitue' ou 'oeuf' dans 'boeuf'."""
+    return re.compile(rf"\b{re.escape(_normalize(term))}\b")
 
 
 def validate(
     plan: FallbackMealPlan, constraints: ConstraintSpec
 ) -> list[ConstraintViolation]:
     """Retourne toutes les violations du plan vis-a-vis des contraintes."""
-    allergens = [a for a in constraints.allergies if a.strip()]
+    allergen_patterns = [
+        (a, _compile_term(a)) for a in constraints.allergies if a.strip()
+    ]
     banned = _DIET_BANNED.get(constraints.diet_type or "", frozenset())
+    banned_patterns = [(t, _compile_term(t)) for t in banned]
     diet_label = constraints.diet_type
     budget_max = constraints.max_daily_budget_eur
 
@@ -133,11 +135,16 @@ def validate(
     for day in plan.days:
         for meal_idx, meal in enumerate(day.meals):
             for ing in meal.ingredients:
+                normalized = _normalize(ing)
                 violations.extend(
-                    _allergen_violations(ing, allergens, day.day, meal_idx)
+                    _allergen_violations(
+                        ing, normalized, allergen_patterns, day.day, meal_idx
+                    )
                 )
                 violations.extend(
-                    _diet_violations(ing, banned, diet_label, day.day, meal_idx)
+                    _diet_violations(
+                        ing, normalized, banned_patterns, diet_label, day.day, meal_idx
+                    )
                 )
         if budget_max is not None:
             violations.extend(_budget_violation(day, budget_max))
@@ -145,7 +152,11 @@ def validate(
 
 
 def _allergen_violations(
-    ingredient: str, allergens: list[str], day_num: int, meal_idx: int
+    ingredient: str,
+    normalized_ingredient: str,
+    allergen_patterns: list[tuple[str, re.Pattern[str]]],
+    day_num: int,
+    meal_idx: int,
 ) -> list[ConstraintViolation]:
     return [
         ConstraintViolation(
@@ -155,14 +166,15 @@ def _allergen_violations(
             ingredient_or_amount=ingredient,
             message=f"Allergene {a!r} present dans {ingredient!r}.",
         )
-        for a in allergens
-        if _ingredient_contains_term(ingredient, a)
+        for a, pattern in allergen_patterns
+        if pattern.search(normalized_ingredient)
     ]
 
 
 def _diet_violations(
     ingredient: str,
-    banned: frozenset[str],
+    normalized_ingredient: str,
+    banned_patterns: list[tuple[str, re.Pattern[str]]],
     diet_type: str | None,
     day_num: int,
     meal_idx: int,
@@ -178,8 +190,8 @@ def _diet_violations(
                 f"{diet_type!r} (terme banni : {term!r})."
             ),
         )
-        for term in banned
-        if _ingredient_contains_term(ingredient, term)
+        for term, pattern in banned_patterns
+        if pattern.search(normalized_ingredient)
     ]
 
 

--- a/app/services/constraint_validator.py
+++ b/app/services/constraint_validator.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from enum import Enum
+
+from app.models.schemas import FallbackMealPlan, MealDay
+
+
+class ViolationType(str, Enum):
+    allergy = "allergy"
+    budget = "budget"
+    diet = "diet"
+
+
+@dataclass(frozen=True)
+class ConstraintSpec:
+    """Contraintes utilisateur : allergies + budget journalier + regime."""
+
+    allergies: list[str] = field(default_factory=list)
+    max_daily_budget_eur: float | None = None
+    diet_type: str | None = None
+
+
+# Heuristique simple : liste non exhaustive d'ingredients incompatibles avec
+# chaque regime alimentaire courant. Le matching reste a frontiere de mot.
+_DIET_BANNED: dict[str, frozenset[str]] = {
+    "vegan": frozenset(
+        {
+            "viande",
+            "boeuf",
+            "poulet",
+            "porc",
+            "agneau",
+            "veau",
+            "dinde",
+            "canard",
+            "jambon",
+            "lardon",
+            "saucisse",
+            "bacon",
+            "poisson",
+            "saumon",
+            "thon",
+            "crevette",
+            "crevettes",
+            "fruit de mer",
+            "fruits de mer",
+            "lait",
+            "laitiere",
+            "fromage",
+            "yaourt",
+            "beurre",
+            "creme",
+            "miel",
+            "oeuf",
+        }
+    ),
+    "vegetarien": frozenset(
+        {
+            "viande",
+            "boeuf",
+            "poulet",
+            "porc",
+            "agneau",
+            "veau",
+            "dinde",
+            "canard",
+            "jambon",
+            "lardon",
+            "saucisse",
+            "bacon",
+            "poisson",
+            "saumon",
+            "thon",
+            "crevette",
+            "crevettes",
+            "fruit de mer",
+            "fruits de mer",
+        }
+    ),
+    "sans_gluten": frozenset(
+        {
+            "ble",
+            "farine de ble",
+            "pain",
+            "pates",
+            "couscous",
+            "boulgour",
+            "seigle",
+            "orge",
+            "avoine",
+        }
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ConstraintViolation:
+    """Violation localisee : type + ou (jour, repas) + valeur fautive + message."""
+
+    type: ViolationType
+    day: int
+    meal_index: int | None
+    ingredient_or_amount: str | float
+    message: str
+
+
+def _normalize(text_value: str) -> str:
+    """Casefold + strip des accents pour matcher 'lait' contre 'Lait écrémé'."""
+    decomposed = unicodedata.normalize("NFD", text_value)
+    stripped = "".join(c for c in decomposed if unicodedata.category(c) != "Mn")
+    return stripped.casefold()
+
+
+def _ingredient_contains_term(ingredient: str, term: str) -> bool:
+    """Match a frontiere de mot, evite 'lait' dans 'laitue' ou 'oeuf' dans 'boeuf'."""
+    pattern = re.compile(rf"\b{re.escape(_normalize(term))}\b")
+    return bool(pattern.search(_normalize(ingredient)))
+
+
+def validate(
+    plan: FallbackMealPlan, constraints: ConstraintSpec
+) -> list[ConstraintViolation]:
+    """Retourne toutes les violations du plan vis-a-vis des contraintes."""
+    allergens = [a for a in constraints.allergies if a.strip()]
+    banned = _DIET_BANNED.get(constraints.diet_type or "", frozenset())
+    diet_label = constraints.diet_type
+    budget_max = constraints.max_daily_budget_eur
+
+    violations: list[ConstraintViolation] = []
+    for day in plan.days:
+        for meal_idx, meal in enumerate(day.meals):
+            for ing in meal.ingredients:
+                violations.extend(
+                    _allergen_violations(ing, allergens, day.day, meal_idx)
+                )
+                violations.extend(
+                    _diet_violations(ing, banned, diet_label, day.day, meal_idx)
+                )
+        if budget_max is not None:
+            violations.extend(_budget_violation(day, budget_max))
+    return violations
+
+
+def _allergen_violations(
+    ingredient: str, allergens: list[str], day_num: int, meal_idx: int
+) -> list[ConstraintViolation]:
+    return [
+        ConstraintViolation(
+            type=ViolationType.allergy,
+            day=day_num,
+            meal_index=meal_idx,
+            ingredient_or_amount=ingredient,
+            message=f"Allergene {a!r} present dans {ingredient!r}.",
+        )
+        for a in allergens
+        if _ingredient_contains_term(ingredient, a)
+    ]
+
+
+def _diet_violations(
+    ingredient: str,
+    banned: frozenset[str],
+    diet_type: str | None,
+    day_num: int,
+    meal_idx: int,
+) -> list[ConstraintViolation]:
+    return [
+        ConstraintViolation(
+            type=ViolationType.diet,
+            day=day_num,
+            meal_index=meal_idx,
+            ingredient_or_amount=ingredient,
+            message=(
+                f"Ingredient {ingredient!r} incompatible avec le regime "
+                f"{diet_type!r} (terme banni : {term!r})."
+            ),
+        )
+        for term in banned
+        if _ingredient_contains_term(ingredient, term)
+    ]
+
+
+def _budget_violation(day: MealDay, budget_max: float) -> list[ConstraintViolation]:
+    day_total = sum(meal.est_budget_eur for meal in day.meals)
+    if day_total <= budget_max:
+        return []
+    return [
+        ConstraintViolation(
+            type=ViolationType.budget,
+            day=day.day,
+            meal_index=None,
+            ingredient_or_amount=day_total,
+            message=(
+                f"Budget journalier {day_total:.2f} EUR "
+                f"depasse la limite {budget_max:.2f} EUR."
+            ),
+        )
+    ]

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -4,9 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
-import re
 import time
-import unicodedata
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -22,6 +20,11 @@ from app.models.schemas import (
     Imbalance,
     PlanInputs,
     RecommendationContext,
+)
+from app.services.constraint_validator import (
+    ConstraintSpec,
+    ViolationType,
+    validate as validate_constraints,
 )
 
 T = TypeVar("T")
@@ -81,7 +84,9 @@ def _sort_keys(obj: Any) -> Any:
 def compute_inputs_hash(inputs: PlanInputs) -> str:
     """SHA256 hex du JSON canonicalise."""
     canonical = canonicalize_inputs(inputs)
-    serialized = json.dumps(canonical, separators=(",", ":"), ensure_ascii=False, sort_keys=True)
+    serialized = json.dumps(
+        canonical, separators=(",", ":"), ensure_ascii=False, sort_keys=True
+    )
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
@@ -223,39 +228,12 @@ def _validate_plan(raw_response: str, inputs: PlanInputs) -> FallbackMealPlan:
     if isinstance(parsed, dict):
         parsed.setdefault("fallback", False)
     plan = FallbackMealPlan.model_validate(parsed)
-    _enforce_allergy_absence(plan, inputs.allergies)
+    if inputs.allergies:
+        spec = ConstraintSpec(allergies=inputs.allergies)
+        for v in validate_constraints(plan, spec):
+            if v.type is ViolationType.allergy:
+                raise _PlanValidationError(v.message)
     return plan
-
-
-def _normalize(text_value: str) -> str:
-    """Casefold + strip des accents pour matcher 'lait' contre 'Lait écrémé'."""
-    decomposed = unicodedata.normalize("NFD", text_value)
-    stripped = "".join(c for c in decomposed if unicodedata.category(c) != "Mn")
-    return stripped.casefold()
-
-
-def _enforce_allergy_absence(plan: FallbackMealPlan, allergies: list[str]) -> None:
-    """Rejette un plan si un ingredient contient un allergene en mot entier.
-
-    Utilise un match a frontiere de mot (\\b) plutot que substring : evite
-    les faux positifs comme 'lait' contre 'laitue' ou 'oeuf' contre 'boeuf'.
-    """
-    if not allergies:
-        return
-    patterns = [
-        (raw, re.compile(rf"\b{re.escape(_normalize(raw))}\b"))
-        for raw in allergies
-        if raw.strip()
-    ]
-    for day in plan.days:
-        for meal in day.meals:
-            for ing in meal.ingredients:
-                normalized_ing = _normalize(ing)
-                for raw_allergen, pattern in patterns:
-                    if pattern.search(normalized_ing):
-                        raise _PlanValidationError(
-                            f"Allergene {raw_allergen!r} present dans {ing!r}."
-                        )
 
 
 def _build_plan_prompt(inputs: PlanInputs) -> str:
@@ -264,11 +242,15 @@ def _build_plan_prompt(inputs: PlanInputs) -> str:
         objective=inputs.objective,
         diet_type=inputs.diet_type or "aucun",
         allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
-        calories_target=inputs.calories_target if inputs.calories_target else "non specifiee",
+        calories_target=inputs.calories_target
+        if inputs.calories_target
+        else "non specifiee",
     )
 
 
-def _lookup_cached_plan(db: Session, user_id: int, inputs_hash: str) -> FallbackMealPlan | None:
+def _lookup_cached_plan(
+    db: Session, user_id: int, inputs_hash: str
+) -> FallbackMealPlan | None:
     """Recupere le dernier plan en cache (< 7 jours) pour ce inputs_hash.
 
     Filtre redondant sur user_id : le hash inclut deja user_id, mais l'expliciter
@@ -291,7 +273,9 @@ def _lookup_cached_plan(db: Session, user_id: int, inputs_hash: str) -> Fallback
     return FallbackMealPlan.model_validate(row.plan)
 
 
-def _persist_plan(db: Session, plan: FallbackMealPlan, inputs_hash: str, inputs: PlanInputs) -> None:
+def _persist_plan(
+    db: Session, plan: FallbackMealPlan, inputs_hash: str, inputs: PlanInputs
+) -> None:
     """Insere une ligne meal_plans avec le plan complet et son inputs_hash.
 
     Flush sans commit : la decision de commit revient au caller (handler FastAPI),

--- a/scripts/eval/llm_metrics.py
+++ b/scripts/eval/llm_metrics.py
@@ -2,84 +2,28 @@ from __future__ import annotations
 
 import csv
 import math
-import re
-import unicodedata
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from app.models.schemas import FallbackMealPlan
+from app.services.constraint_validator import (
+    ConstraintSpec,
+    ViolationType,
+    validate as validate_constraints,
+)
 
-# Heuristique simple pour le respect du regime alimentaire (vegan, vegetarien,
-# sans_gluten). Liste non exhaustive : c'est une eval, pas un nutritionniste.
-_DIET_BANNED: dict[str, frozenset[str]] = {
-    "vegan": frozenset(
-        {
-            "viande",
-            "boeuf",
-            "poulet",
-            "porc",
-            "agneau",
-            "veau",
-            "dinde",
-            "canard",
-            "jambon",
-            "lardon",
-            "saucisse",
-            "bacon",
-            "poisson",
-            "saumon",
-            "thon",
-            "crevette",
-            "crevettes",
-            "fruit de mer",
-            "fruits de mer",
-            "lait",
-            "laitiere",
-            "fromage",
-            "yaourt",
-            "beurre",
-            "creme",
-            "miel",
-            "oeuf",
-        }
-    ),
-    "vegetarien": frozenset(
-        {
-            "viande",
-            "boeuf",
-            "poulet",
-            "porc",
-            "agneau",
-            "veau",
-            "dinde",
-            "canard",
-            "jambon",
-            "lardon",
-            "saucisse",
-            "bacon",
-            "poisson",
-            "saumon",
-            "thon",
-            "crevette",
-            "crevettes",
-            "fruit de mer",
-            "fruits de mer",
-        }
-    ),
-    "sans_gluten": frozenset(
-        {
-            "ble",
-            "farine de ble",
-            "pain",
-            "pates",
-            "couscous",
-            "boulgour",
-            "seigle",
-            "orge",
-            "avoine",
-        }
-    ),
-}
+__all__ = [
+    "ConstraintCheck",
+    "ConstraintSpec",
+    "GenerationOutcome",
+    "HitlSummary",
+    "check_plan_constraints",
+    "constraint_satisfaction_rate",
+    "fallback_rate",
+    "json_validity_rate",
+    "latency_percentiles",
+    "load_hitl_ratings",
+]
 
 
 @dataclass(frozen=True)
@@ -141,62 +85,20 @@ def constraint_satisfaction_rate(checks: list[ConstraintCheck]) -> float:
     return sum(1 for c in checks if c.all_satisfied()) / len(checks)
 
 
-@dataclass(frozen=True)
-class ConstraintSpec:
-    """Contraintes a verifier sur un plan : allergies + budget + regime."""
-
-    allergies: list[str] = field(default_factory=list)
-    max_daily_budget_eur: float | None = None
-    diet_type: str | None = None
-
-
-def _normalize(text_value: str) -> str:
-    decomposed = unicodedata.normalize("NFD", text_value)
-    stripped = "".join(c for c in decomposed if unicodedata.category(c) != "Mn")
-    return stripped.casefold()
-
-
-def _ingredient_contains_term(ingredient: str, term: str) -> bool:
-    """Match a frontiere de mot, comme llm_client._enforce_allergy_absence."""
-    pattern = re.compile(rf"\b{re.escape(_normalize(term))}\b")
-    return bool(pattern.search(_normalize(ingredient)))
-
-
-def _plan_violates_terms(plan: FallbackMealPlan, terms: frozenset[str] | list[str]) -> bool:
-    """True des qu'un ingredient du plan matche un des termes (frontiere de mot)."""
-    return any(
-        _ingredient_contains_term(ing, term)
-        for day in plan.days
-        for meal in day.meals
-        for ing in meal.ingredients
-        for term in terms
-    )
-
-
 def check_plan_constraints(
     plan: FallbackMealPlan,
     spec: ConstraintSpec,
 ) -> ConstraintCheck:
-    """Verifie qu'un plan respecte allergies + budget + regime."""
-    allergies_absent = not (
-        spec.allergies and _plan_violates_terms(plan, spec.allergies)
-    )
+    """Verifie qu'un plan respecte allergies + budget + regime.
 
-    budget_respected = True
-    if spec.max_daily_budget_eur is not None:
-        for day in plan.days:
-            day_cost = sum(meal.est_budget_eur for meal in day.meals)
-            if day_cost > spec.max_daily_budget_eur:
-                budget_respected = False
-                break
-
-    banned = _DIET_BANNED.get(spec.diet_type or "", frozenset())
-    diet_respected = not (banned and _plan_violates_terms(plan, banned))
-
+    Adaptateur autour de constraint_validator.validate : agrege les violations
+    granulaires en trois drapeaux booleens pour l'eval.
+    """
+    types = {v.type for v in validate_constraints(plan, spec)}
     return ConstraintCheck(
-        allergies_absent=allergies_absent,
-        budget_respected=budget_respected,
-        diet_respected=diet_respected,
+        allergies_absent=ViolationType.allergy not in types,
+        budget_respected=ViolationType.budget not in types,
+        diet_respected=ViolationType.diet not in types,
     )
 
 

--- a/tests/unit/test_constraint_validator.py
+++ b/tests/unit/test_constraint_validator.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from app.models.schemas import FallbackMealPlan
+from app.services.constraint_validator import (
+    ConstraintSpec,
+    ViolationType,
+    validate,
+)
+
+
+def _plan(
+    *,
+    ingredients: list[str] | None = None,
+    cost_eur: float = 5.0,
+    day: int = 1,
+) -> FallbackMealPlan:
+    return FallbackMealPlan.model_validate(
+        {
+            "fallback": False,
+            "days": [
+                {
+                    "day": day,
+                    "meals": [
+                        {
+                            "name": "lunch",
+                            "macros": {
+                                "calories": 500,
+                                "protein_g": 30,
+                                "carbs_g": 60,
+                                "fat_g": 15,
+                            },
+                            "ingredients": list(ingredients or ["riz", "poulet"]),
+                            "est_budget_eur": cost_eur,
+                            "prep_time_min": 20,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def test_validate_returns_empty_list_when_spec_has_no_constraints() -> None:
+    plan = _plan(ingredients=["riz", "poulet"], cost_eur=4.0)
+    spec = ConstraintSpec()  # pas d'allergies, pas de budget, pas de regime
+
+    assert validate(plan, spec) == []
+
+
+def test_allergy_matched_at_word_boundary() -> None:
+    plan = _plan(ingredients=["lait ecreme", "cafe"])
+    spec = ConstraintSpec(allergies=["lait"])
+
+    violations = validate(plan, spec)
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.type is ViolationType.allergy
+    assert v.day == 1
+    assert v.meal_index == 0
+    assert v.ingredient_or_amount == "lait ecreme"
+    assert "lait" in v.message
+
+
+def test_allergy_does_not_false_positive_on_substring() -> None:
+    # 'lait' ne doit pas matcher 'laitue', 'oeuf' ne doit pas matcher 'boeuf'.
+    plan = _plan(ingredients=["laitue", "boeuf braise", "tomate"])
+    spec = ConstraintSpec(allergies=["lait", "oeuf"])
+
+    assert validate(plan, spec) == []
+
+
+def test_allergy_match_strips_accents_and_case() -> None:
+    plan = _plan(ingredients=["Lait écrémé", "céréales"])
+    spec = ConstraintSpec(allergies=["lait"])
+
+    violations = validate(plan, spec)
+
+    assert len(violations) == 1
+    assert violations[0].ingredient_or_amount == "Lait écrémé"
+
+
+def test_budget_within_limit_returns_no_violation() -> None:
+    plan = _plan(cost_eur=8.0)
+    spec = ConstraintSpec(max_daily_budget_eur=10.0)
+
+    assert validate(plan, spec) == []
+
+
+def test_budget_exceeded_reports_day_total() -> None:
+    plan = _plan(cost_eur=12.0, day=2)
+    spec = ConstraintSpec(max_daily_budget_eur=10.0)
+
+    violations = validate(plan, spec)
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.type is ViolationType.budget
+    assert v.day == 2
+    assert v.meal_index is None
+    assert v.ingredient_or_amount == 12.0
+    assert "10" in v.message  # mentionne la limite
+
+
+def test_diet_vegan_flags_meat_ingredient() -> None:
+    plan = _plan(ingredients=["poulet roti", "riz"])
+    spec = ConstraintSpec(diet_type="vegan")
+
+    violations = validate(plan, spec)
+
+    diet_violations = [v for v in violations if v.type is ViolationType.diet]
+    assert len(diet_violations) == 1
+    assert diet_violations[0].ingredient_or_amount == "poulet roti"
+    assert diet_violations[0].day == 1
+    assert diet_violations[0].meal_index == 0
+
+
+def test_diet_sans_gluten_flags_ble() -> None:
+    plan = _plan(ingredients=["pates au ble", "tomate"])
+    spec = ConstraintSpec(diet_type="sans_gluten")
+
+    violations = validate(plan, spec)
+
+    diet_violations = [v for v in violations if v.type is ViolationType.diet]
+    # 'pates' et 'ble' sont tous deux bannis -> deux violations sur le meme ingredient.
+    assert len(diet_violations) >= 1
+    assert all(v.day == 1 and v.meal_index == 0 for v in diet_violations)
+
+
+def test_diet_omnivore_has_no_banned_set() -> None:
+    plan = _plan(ingredients=["poulet", "boeuf", "riz"])
+    spec = ConstraintSpec(diet_type="omnivore")
+
+    assert validate(plan, spec) == []
+
+
+def _multi_day_plan(days: list[dict]) -> FallbackMealPlan:
+    return FallbackMealPlan.model_validate({"fallback": False, "days": days})
+
+
+def _meal(*, ingredients: list[str], cost: float = 5.0) -> dict:
+    return {
+        "name": "meal",
+        "macros": {"calories": 500, "protein_g": 30, "carbs_g": 60, "fat_g": 15},
+        "ingredients": ingredients,
+        "est_budget_eur": cost,
+        "prep_time_min": 20,
+    }
+
+
+def test_multi_violations_are_all_reported_no_short_circuit() -> None:
+    plan = _multi_day_plan(
+        [
+            {
+                "day": 1,
+                "meals": [
+                    _meal(ingredients=["poulet roti", "lait"], cost=8.0),
+                    _meal(ingredients=["riz"], cost=5.0),  # day 1 total = 13 EUR
+                ],
+            },
+            {
+                "day": 2,
+                "meals": [_meal(ingredients=["tofu", "riz"], cost=3.0)],
+            },
+        ]
+    )
+    spec = ConstraintSpec(
+        allergies=["lait"], max_daily_budget_eur=10.0, diet_type="vegan"
+    )
+
+    violations = validate(plan, spec)
+
+    by_type = {t: [v for v in violations if v.type is t] for t in ViolationType}
+    # Allergie 'lait' dans le repas 0 du jour 1
+    assert any(
+        v.day == 1 and v.meal_index == 0 and v.ingredient_or_amount == "lait"
+        for v in by_type[ViolationType.allergy]
+    )
+    # Diet vegan : 'poulet roti' dans le repas 0 du jour 1, et 'lait' aussi
+    assert any(
+        v.day == 1 and v.meal_index == 0 and v.ingredient_or_amount == "poulet roti"
+        for v in by_type[ViolationType.diet]
+    )
+    # Budget jour 1 = 13 EUR > 10 EUR
+    assert any(
+        v.day == 1 and v.meal_index is None and v.ingredient_or_amount == 13.0
+        for v in by_type[ViolationType.budget]
+    )
+    # Le jour 2 est conforme : pas de violation jour 2
+    assert all(v.day != 2 for v in violations)
+
+
+def test_plan_respecting_all_three_constraints_returns_empty() -> None:
+    plan = _multi_day_plan(
+        [
+            {
+                "day": 1,
+                "meals": [
+                    _meal(ingredients=["tofu", "quinoa", "epinards"], cost=6.0),
+                    _meal(ingredients=["lentilles", "carottes"], cost=3.5),
+                ],
+            }
+        ]
+    )
+    spec = ConstraintSpec(
+        allergies=["arachide"], max_daily_budget_eur=12.0, diet_type="vegan"
+    )
+
+    assert validate(plan, spec) == []

--- a/tests/unit/test_constraint_validator.py
+++ b/tests/unit/test_constraint_validator.py
@@ -123,7 +123,7 @@ def test_diet_sans_gluten_flags_ble() -> None:
 
     diet_violations = [v for v in violations if v.type is ViolationType.diet]
     # 'pates' et 'ble' sont tous deux bannis -> deux violations sur le meme ingredient.
-    assert len(diet_violations) >= 1
+    assert len(diet_violations) == 2
     assert all(v.day == 1 and v.meal_index == 0 for v in diet_violations)
 
 


### PR DESCRIPTION
Closes #48

## Summary
- Nouveau module `app/services/constraint_validator.py` qui valide allergies, budget journalier et regime alimentaire d'un `FallbackMealPlan`. `validate(plan, ConstraintSpec)` retourne la liste complete de `ConstraintViolation` (`type`, `day`, `meal_index`, `ingredient_or_amount`, `message`) sans court-circuit. Word-boundary matching preserve (anti faux positifs `lait`/`laitue`, `oeuf`/`boeuf`).
- Migration : `_enforce_allergy_absence` supprime de `llm_client`, le call site dans `_validate_plan` passe par `validate_constraints` (mode allergies, le branchement budget+regime arrive en Slice 6 par decision issue). `_DIET_BANNED` et `ConstraintSpec` deplaces dans le nouveau module ; `scripts/eval/llm_metrics` re-exporte `ConstraintSpec` et reduit `check_plan_constraints` a un adapteur.
- 11 tests unitaires sur le validator (tracer, allergie frontiere de mot, anti faux positif, accents/casse, budget OK, budget depasse, diet vegan, diet sans_gluten, omnivore no-op, multi-violations multi-jours, cas full positive). Suite complete `pytest -m 'not slow'` : 256 passes.

## Test plan
- [x] `pytest tests/unit/test_constraint_validator.py` (11 passes)
- [x] `pytest tests/unit/test_llm_client.py` (25 passes, comportement allergie inchange)
- [x] `pytest tests/unit/test_eval_llm_metrics.py` (15 passes, adapteur compatible)
- [x] `pytest -m 'not slow'` complet (256 passes)
- [x] `ruff check` + `ruff format --check` sur les fichiers modifies
- [ ] Verifier en revue : decision de garder le decoupage Slice 6 pour le branchement budget+regime au niveau du `_validate_plan` (uniquement allergies enforce le retry pour l'instant)