### PR TITLE
[Slice 11] Eval terrain : 50 a 100 photos telephone avec labels manuels

### DIFF
--- a/data/eval_terrain/README.md
+++ b/data/eval_terrain/README.md
@@ -2,33 +2,39 @@
 
 ## Objectif
 
-50 photos prises au telephone (repas reels, restaurants, plats maison)
+50 a 100 photos prises au telephone (repas reels, restaurants, plats maison)
 avec annotation manuelle, pour mesurer l'ecart entre l'accuracy academique
 (Food-101 test split) et la realite des photos utilisateur.
 
-Cible : 50 photos couvrant un mix de classes Food-101.
+Cible : 50 a 100 photos couvrant un mix de classes Food-101 + quelques plats
+hors-distribution (label `unknown`) pour mesurer le taux de plats absents
+de Food-101.
 
 ## Format
 
-- Photos : `.jpg` ou `.png` dans ce dossier (`data/eval_terrain/`)
-- Annotations : `labels.csv` au format
+- Photos : `.jpg` ou `.png` dans `data/eval_terrain/images/`
+- Annotations : `data/eval_terrain/labels.csv` au format
   ```
-  filename,label
+  filename,label_food101
   IMG_001.jpg,pizza
   IMG_002.jpg,sushi
+  IMG_003.jpg,unknown
   ```
-- `label` doit etre une classe Food-101 (snake_case, ex: `grilled_salmon`,
-  `caesar_salad`). Liste complete : voir `nateraw/food` sur HuggingFace.
-- Si la photo represente un plat hors des 101 classes, l'omettre :
-  l'eval ne couvre que la distribution Food-101.
+- `label_food101` doit etre une classe Food-101 (snake_case, ex:
+  `grilled_salmon`, `caesar_salad`). Liste complete : voir `nateraw/food`
+  sur HuggingFace.
+- Si la photo represente un plat hors des 101 classes, utiliser le label
+  special `unknown` : il sera comptabilise dans `unknown_rate` mais exclu
+  des metriques top-1 / top-5.
 
 ## Workflow
 
-1. Prendre 50 photos varie : eclairage, angle, plats composites,
-   restaurants, cantine, maison.
+1. Prendre 50 a 100 photos variees : eclairage, angle, plats composites,
+   restaurants, cantine, maison, plats hors Food-101.
 2. Renommer en `IMG_NNN.jpg` (3 chiffres) pour rester ordonne.
-3. Editer `labels.csv` en ajoutant une ligne par photo.
-4. Lancer `python scripts/eval_metrics.py classifier --terrain-dir data/eval_terrain/`.
+3. Deposer les photos dans `data/eval_terrain/images/`.
+4. Editer `labels.csv` en ajoutant une ligne par photo.
+5. Lancer `python scripts/eval_metrics.py classifier --terrain-dir data/eval_terrain/`.
 
 ## Reproductibilite
 

--- a/data/eval_terrain/labels.csv
+++ b/data/eval_terrain/labels.csv
@@ -1,1 +1,1 @@
-filename,label
+filename,label_food101

--- a/scripts/eval/classifier_runner.py
+++ b/scripts/eval/classifier_runner.py
@@ -22,11 +22,18 @@ from scripts.eval.classifier_metrics import (
     top_k_accuracy,
 )
 from scripts.eval.plotting import save_confusion_matrix_png
-from scripts.eval.terrain import load_terrain_labels
+from scripts.eval.terrain import UNKNOWN_LABEL, load_terrain_labels
 
 logger = logging.getLogger(__name__)
 
 _MODEL_ID = "nateraw/food"
+
+_EMPTY_TERRAIN_PAYLOAD: dict[str, Any] = {
+    "n_samples": 0,
+    "top1_accuracy": 0.0,
+    "top5_accuracy": 0.0,
+    "unknown_rate": 0.0,
+}
 
 
 def run_classifier_eval(
@@ -117,14 +124,6 @@ def _eval_food101(classifier: Any, n_samples: int, output_dir: Path) -> dict[str
     }
 
 
-_EMPTY_TERRAIN_PAYLOAD: dict[str, Any] = {
-    "n_samples": 0,
-    "top1_accuracy": 0.0,
-    "top5_accuracy": 0.0,
-    "unknown_rate": 0.0,
-}
-
-
 def _eval_terrain(classifier: Any, terrain_dir: Path) -> dict[str, Any]:
     labels_csv = terrain_dir / "labels.csv"
     if not labels_csv.exists():
@@ -148,7 +147,7 @@ def _eval_terrain(classifier: Any, terrain_dir: Path) -> dict[str, Any]:
     top5_preds: list[list[str]] = []
     truths: list[str] = []
     for sample in samples:
-        if sample.label == "unknown":
+        if sample.label == UNKNOWN_LABEL:
             # Plat hors-distribution Food-101 : compte dans unknown_rate
             # mais n'est pas envoye au classifier.
             n_unknown += 1

--- a/scripts/eval/classifier_runner.py
+++ b/scripts/eval/classifier_runner.py
@@ -45,13 +45,8 @@ def run_classifier_eval(
     classifier = _load_classifier()
     payload: dict[str, Any] = {}
 
-    food101_payload = _eval_food101(classifier, n_food101, output_dir)
-    payload["food101"] = food101_payload
-
-    terrain_payload = _eval_terrain(classifier, terrain_dir)
-    if terrain_payload is not None:
-        payload["terrain"] = terrain_payload
-
+    payload["food101"] = _eval_food101(classifier, n_food101, output_dir)
+    payload["terrain"] = _eval_terrain(classifier, terrain_dir)
     return payload
 
 
@@ -61,9 +56,7 @@ def _load_classifier() -> Any:
     return pipeline("image-classification", model=_MODEL_ID)
 
 
-def _eval_food101(
-    classifier: Any, n_samples: int, output_dir: Path
-) -> dict[str, Any]:
+def _eval_food101(classifier: Any, n_samples: int, output_dir: Path) -> dict[str, Any]:
     """Echantillonne n_samples du test split Food-101 et calcule les metriques.
 
     On prend les `n_samples` premiers du split (deterministe, ordre du dataset
@@ -124,9 +117,15 @@ def _eval_food101(
     }
 
 
-def _eval_terrain(
-    classifier: Any, terrain_dir: Path
-) -> dict[str, Any] | None:
+_EMPTY_TERRAIN_PAYLOAD: dict[str, Any] = {
+    "n_samples": 0,
+    "top1_accuracy": 0.0,
+    "top5_accuracy": 0.0,
+    "unknown_rate": 0.0,
+}
+
+
+def _eval_terrain(classifier: Any, terrain_dir: Path) -> dict[str, Any]:
     labels_csv = terrain_dir / "labels.csv"
     if not labels_csv.exists():
         logger.warning(
@@ -135,18 +134,26 @@ def _eval_terrain(
             labels_csv,
             terrain_dir,
         )
-        return None
+        return dict(_EMPTY_TERRAIN_PAYLOAD)
 
     samples = load_terrain_labels(labels_csv)
     if not samples:
         logger.warning("terrain : %s est vide", labels_csv)
-        return None
+        return dict(_EMPTY_TERRAIN_PAYLOAD)
 
+    images_dir = terrain_dir / "images"
+    n_samples = len(samples)
+    n_unknown = 0
     top1_preds: list[str] = []
     top5_preds: list[list[str]] = []
     truths: list[str] = []
     for sample in samples:
-        img_path = terrain_dir / sample.filename
+        if sample.label == "unknown":
+            # Plat hors-distribution Food-101 : compte dans unknown_rate
+            # mais n'est pas envoye au classifier.
+            n_unknown += 1
+            continue
+        img_path = images_dir / sample.filename
         if not img_path.exists():
             logger.warning("terrain : image %s manquante, ignoree", img_path)
             continue
@@ -157,15 +164,20 @@ def _eval_terrain(
         top5_preds.append(top5)
         truths.append(sample.label)
 
+    unknown_rate = n_unknown / n_samples if n_samples else 0.0
     if not truths:
-        return None
+        return {
+            "n_samples": n_samples,
+            "top1_accuracy": 0.0,
+            "top5_accuracy": 0.0,
+            "unknown_rate": unknown_rate,
+        }
 
     top1_acc = top_k_accuracy([[p] for p in top1_preds], truths, k=1)
     top5_acc = top_k_accuracy(top5_preds, truths, k=5)
-    metrics = per_class_metrics(top1_preds, truths)
     return {
-        "n_samples": len(truths),
+        "n_samples": n_samples,
         "top1_accuracy": top1_acc,
         "top5_accuracy": top5_acc,
-        "per_class": metrics,
+        "unknown_rate": unknown_rate,
     }

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -71,7 +71,12 @@ def _render_classifier_section(data: dict[str, Any]) -> list[str]:
         )
         out.append("")
 
-    if food101 and terrain and terrain.get("n_samples", 0) > 0:
+    if (
+        food101
+        and terrain
+        and terrain.get("n_samples", 0) > 0
+        and terrain.get("unknown_rate", 0.0) < 1.0
+    ):
         out.append("### Comparaison Food-101 vs terrain")
         out.append("")
         delta_top1 = food101.get("top1_accuracy", 0.0) - terrain.get(

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -60,14 +60,18 @@ def _render_classifier_section(data: dict[str, Any]) -> list[str]:
 
     terrain = data.get("terrain")
     if terrain:
-        out.append("### Terrain (50 photos manuelles)")
+        out.append("### Terrain (photos telephone, eval HITL)")
         out.append("")
         out.append(f"- N samples : {terrain.get('n_samples', 0)}")
         out.append(f"- Top-1 accuracy : {terrain.get('top1_accuracy', 0.0):.4f}")
         out.append(f"- Top-5 accuracy : {terrain.get('top5_accuracy', 0.0):.4f}")
+        out.append(
+            f"- Unknown_rate (plats hors-distribution Food-101) : "
+            f"{terrain.get('unknown_rate', 0.0):.4f}"
+        )
         out.append("")
 
-    if food101 and terrain:
+    if food101 and terrain and terrain.get("n_samples", 0) > 0:
         out.append("### Comparaison Food-101 vs terrain")
         out.append("")
         delta_top1 = food101.get("top1_accuracy", 0.0) - terrain.get(

--- a/scripts/eval/terrain.py
+++ b/scripts/eval/terrain.py
@@ -4,6 +4,8 @@ import csv
 from dataclasses import dataclass
 from pathlib import Path
 
+UNKNOWN_LABEL = "unknown"
+
 
 @dataclass(frozen=True)
 class TerrainSample:

--- a/scripts/eval/terrain.py
+++ b/scripts/eval/terrain.py
@@ -15,15 +15,16 @@ def load_terrain_labels(csv_path: Path) -> list[TerrainSample]:
     """Lit data/eval_terrain/labels.csv -> liste de samples annotes."""
     with csv_path.open(newline="", encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
-        if reader.fieldnames is None or set(reader.fieldnames) < {"filename", "label"}:
+        required = {"filename", "label_food101"}
+        if reader.fieldnames is None or required - set(reader.fieldnames):
             raise ValueError(
-                f"CSV {csv_path} doit avoir les colonnes filename,label "
+                f"CSV {csv_path} doit avoir les colonnes filename,label_food101 "
                 f"(trouve : {reader.fieldnames})"
             )
         samples: list[TerrainSample] = []
         for row in reader:
             filename = (row.get("filename") or "").strip()
-            label = (row.get("label") or "").strip()
+            label = (row.get("label_food101") or "").strip()
             if not filename or not label:
                 continue
             samples.append(TerrainSample(filename=filename, label=label))

--- a/tests/unit/test_eval_report.py
+++ b/tests/unit/test_eval_report.py
@@ -75,3 +75,28 @@ def test_render_metrics_md_includes_required_sections(tmp_path: Path) -> None:
     # Embed des PNGs
     assert "docs/confusion_matrix_food101.png" in content
     assert "docs/llm_latency.png" in content
+
+
+def test_render_metrics_md_includes_terrain_unknown_rate(tmp_path: Path) -> None:
+    payload = {
+        "classifier": {
+            "food101": {
+                "top1_accuracy": 0.71,
+                "top5_accuracy": 0.92,
+                "n_samples": 1000,
+            },
+            "terrain": {
+                "n_samples": 50,
+                "top1_accuracy": 0.45,
+                "top5_accuracy": 0.7,
+                "unknown_rate": 0.1,
+            },
+        }
+    }
+    out = tmp_path / "metrics.md"
+
+    render_metrics_md(payload, out)
+
+    content = out.read_text(encoding="utf-8")
+    assert "unknown_rate" in content.lower() or "hors-distribution" in content.lower()
+    assert "0.10" in content or "10.0" in content or "10 %" in content

--- a/tests/unit/test_eval_report.py
+++ b/tests/unit/test_eval_report.py
@@ -77,6 +77,34 @@ def test_render_metrics_md_includes_required_sections(tmp_path: Path) -> None:
     assert "docs/llm_latency.png" in content
 
 
+def test_render_metrics_md_hides_comparison_when_all_terrain_unknown(
+    tmp_path: Path,
+) -> None:
+    # n_samples > 0 mais unknown_rate == 1.0 -> truths vide cote runner,
+    # top1 == 0.0 ; afficher la comparaison serait trompeur.
+    payload = {
+        "classifier": {
+            "food101": {
+                "top1_accuracy": 0.71,
+                "top5_accuracy": 0.92,
+                "n_samples": 1000,
+            },
+            "terrain": {
+                "n_samples": 5,
+                "top1_accuracy": 0.0,
+                "top5_accuracy": 0.0,
+                "unknown_rate": 1.0,
+            },
+        }
+    }
+    out = tmp_path / "metrics.md"
+
+    render_metrics_md(payload, out)
+
+    content = out.read_text(encoding="utf-8")
+    assert "Comparaison Food-101 vs terrain" not in content
+
+
 def test_render_metrics_md_includes_terrain_unknown_rate(tmp_path: Path) -> None:
     payload = {
         "classifier": {

--- a/tests/unit/test_eval_terrain.py
+++ b/tests/unit/test_eval_terrain.py
@@ -1,15 +1,178 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
+from PIL import Image
 
+from scripts.eval.classifier_runner import _eval_terrain
 from scripts.eval.terrain import TerrainSample, load_terrain_labels
+
+
+def _stub_classifier(*results_per_call: list[dict[str, Any]]):
+    """Renvoie un fake classifier qui retourne `results_per_call[i]` au i-eme appel."""
+    calls = iter(results_per_call)
+
+    def _call(image: Any, top_k: int = 5) -> list[dict[str, Any]]:
+        return next(calls)[:top_k]
+
+    return _call
+
+
+def _write_image(path: Path) -> None:
+    Image.new("RGB", (8, 8), color=(255, 0, 0)).save(path, format="JPEG")
+
+
+def test_eval_terrain_returns_zeros_dict_when_csv_missing(tmp_path: Path) -> None:
+    classifier = _stub_classifier()  # ne sera jamais appele
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload == {
+        "n_samples": 0,
+        "top1_accuracy": 0.0,
+        "top5_accuracy": 0.0,
+        "unknown_rate": 0.0,
+    }
+
+
+def test_eval_terrain_returns_zeros_dict_when_csv_has_header_only(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "labels.csv").write_text("filename,label_food101\n", encoding="utf-8")
+    classifier = _stub_classifier()
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload == {
+        "n_samples": 0,
+        "top1_accuracy": 0.0,
+        "top5_accuracy": 0.0,
+        "unknown_rate": 0.0,
+    }
+
+
+def test_eval_terrain_top1_and_top5_hit_on_normal_sample(tmp_path: Path) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    _write_image(images_dir / "img_001.jpg")
+    (tmp_path / "labels.csv").write_text(
+        "filename,label_food101\nimg_001.jpg,pizza\n", encoding="utf-8"
+    )
+    classifier = _stub_classifier(
+        [
+            {"label": "pizza", "score": 0.9},
+            {"label": "lasagna", "score": 0.05},
+            {"label": "spaghetti_bolognese", "score": 0.02},
+            {"label": "ravioli", "score": 0.02},
+            {"label": "carbonara", "score": 0.01},
+        ]
+    )
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload == {
+        "n_samples": 1,
+        "top1_accuracy": 1.0,
+        "top5_accuracy": 1.0,
+        "unknown_rate": 0.0,
+    }
+
+
+def test_eval_terrain_top1_miss_top5_hit(tmp_path: Path) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    _write_image(images_dir / "img_001.jpg")
+    (tmp_path / "labels.csv").write_text(
+        "filename,label_food101\nimg_001.jpg,pizza\n", encoding="utf-8"
+    )
+    classifier = _stub_classifier(
+        [
+            {"label": "lasagna", "score": 0.6},
+            {"label": "pizza", "score": 0.3},
+            {"label": "spaghetti_bolognese", "score": 0.05},
+            {"label": "ravioli", "score": 0.03},
+            {"label": "carbonara", "score": 0.02},
+        ]
+    )
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload["n_samples"] == 1
+    assert payload["top1_accuracy"] == 0.0
+    assert payload["top5_accuracy"] == 1.0
+    assert payload["unknown_rate"] == 0.0
+
+
+def test_eval_terrain_unknown_label_only_contributes_to_unknown_rate(
+    tmp_path: Path,
+) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    _write_image(images_dir / "img_001.jpg")
+    _write_image(images_dir / "img_002.jpg")
+    (tmp_path / "labels.csv").write_text(
+        "filename,label_food101\nimg_001.jpg,pizza\nimg_002.jpg,unknown\n",
+        encoding="utf-8",
+    )
+    classifier = _stub_classifier(
+        [
+            {"label": "pizza", "score": 0.9},
+            {"label": "lasagna", "score": 0.05},
+            {"label": "spaghetti_bolognese", "score": 0.02},
+            {"label": "ravioli", "score": 0.02},
+            {"label": "carbonara", "score": 0.01},
+        ],
+        [
+            {"label": "tiramisu", "score": 0.4},
+            {"label": "creme_brulee", "score": 0.3},
+            {"label": "panna_cotta", "score": 0.15},
+            {"label": "chocolate_mousse", "score": 0.1},
+            {"label": "ice_cream", "score": 0.05},
+        ],
+    )
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload == {
+        "n_samples": 2,
+        "top1_accuracy": 1.0,
+        "top5_accuracy": 1.0,
+        "unknown_rate": 0.5,
+    }
+
+
+def test_eval_terrain_only_unknown_samples_yields_zero_accuracy(tmp_path: Path) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    _write_image(images_dir / "img_001.jpg")
+    (tmp_path / "labels.csv").write_text(
+        "filename,label_food101\nimg_001.jpg,unknown\n", encoding="utf-8"
+    )
+    classifier = _stub_classifier(
+        [
+            {"label": "pizza", "score": 0.9},
+            {"label": "lasagna", "score": 0.05},
+            {"label": "spaghetti_bolognese", "score": 0.02},
+            {"label": "ravioli", "score": 0.02},
+            {"label": "carbonara", "score": 0.01},
+        ]
+    )
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    assert payload == {
+        "n_samples": 1,
+        "top1_accuracy": 0.0,
+        "top5_accuracy": 0.0,
+        "unknown_rate": 1.0,
+    }
 
 
 def test_load_terrain_labels_reads_csv(tmp_path: Path) -> None:
     csv = tmp_path / "labels.csv"
-    csv.write_text("filename,label\nimg_001.jpg,pizza\nimg_002.jpg,sushi\n")
+    csv.write_text("filename,label_food101\nimg_001.jpg,pizza\nimg_002.jpg,sushi\n")
 
     samples = load_terrain_labels(csv)
 
@@ -21,7 +184,7 @@ def test_load_terrain_labels_reads_csv(tmp_path: Path) -> None:
 
 def test_load_terrain_labels_skips_blank_rows(tmp_path: Path) -> None:
     csv = tmp_path / "labels.csv"
-    csv.write_text("filename,label\nimg_001.jpg,pizza\n,\nimg_002.jpg,sushi\n")
+    csv.write_text("filename,label_food101\nimg_001.jpg,pizza\n,\nimg_002.jpg,sushi\n")
 
     samples = load_terrain_labels(csv)
 

--- a/tests/unit/test_eval_terrain.py
+++ b/tests/unit/test_eval_terrain.py
@@ -143,6 +143,34 @@ def test_eval_terrain_unknown_label_only_contributes_to_unknown_rate(
     }
 
 
+def test_eval_terrain_skips_missing_image_files(tmp_path: Path) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    _write_image(images_dir / "img_001.jpg")
+    # img_002.jpg est referencee dans le CSV mais absente du dossier images/
+    (tmp_path / "labels.csv").write_text(
+        "filename,label_food101\nimg_001.jpg,pizza\nimg_002.jpg,sushi\n",
+        encoding="utf-8",
+    )
+    classifier = _stub_classifier(
+        [
+            {"label": "pizza", "score": 0.9},
+            {"label": "lasagna", "score": 0.05},
+            {"label": "spaghetti_bolognese", "score": 0.02},
+            {"label": "ravioli", "score": 0.02},
+            {"label": "carbonara", "score": 0.01},
+        ]
+    )
+
+    payload = _eval_terrain(classifier, tmp_path)
+
+    # n_samples reflete le CSV (2), mais seul img_001 a ete classe.
+    assert payload["n_samples"] == 2
+    assert payload["top1_accuracy"] == 1.0
+    assert payload["top5_accuracy"] == 1.0
+    assert payload["unknown_rate"] == 0.0
+
+
 def test_eval_terrain_only_unknown_samples_yields_zero_accuracy(tmp_path: Path) -> None:
     images_dir = tmp_path / "images"
     images_dir.mkdir()


### PR DESCRIPTION
Closes #50

## Summary

Etend `_eval_terrain` dans `scripts/eval/classifier_runner.py` pour aligner le runner avec la spec de l'issue #50 :

- CSV `data/eval_terrain/labels.csv` : colonne renommee `label` -> `label_food101` (clarifie l'espace de labels)
- Photos terrain placees dans `data/eval_terrain/images/<filename>` (separation des annotations et des images)
- Label special `unknown` : comptabilise dans `unknown_rate` et exclu des metriques top-1 / top-5
- `_eval_terrain` retourne toujours un `dict` (n_samples=0 si CSV absent ou vide) au lieu de `None`, garantissant que `classifier.terrain` est toujours present dans `docs/metrics.json`
- `report.py` rend `unknown_rate` et n'affiche la comparaison Food-101 vs terrain que si `n_samples > 0`

## Hors scope (HITL, Arthur)

- Collecte des 50-100 photos
- Remplissage de `labels.csv`
- Mise a jour de `docs/metrics.md` avec les chiffres reels terrain (ils seront generes par le runner une fois le dataset annote)

## Test plan

- [x] `pytest tests/unit/test_eval_terrain.py` (9 tests) : cases CSV absent, header seul, top-1 hit, top-5 hit, label unknown mixte, only-unknown, load_terrain_labels
- [x] `pytest tests/unit/test_eval_report.py` (3 tests) : rendering MD inclut `unknown_rate`
- [x] `ruff check` + `ruff format --check` sur les fichiers modifies
- [ ] (HITL) Apres labeling : lancer `python scripts/eval_metrics.py classifier --n-food101 1000 --terrain-dir data/eval_terrain/` et verifier la section `classifier.terrain` dans `docs/metrics.json`