### PR TITLE
[Slice 1] Migration V11 BDD + persistance des nouveaux champs

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Column, DateTime, Integer, Numeric, String, text
+from sqlalchemy import BigInteger, Column, DateTime, Integer, Numeric, String, Text, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import DeclarativeBase
 
@@ -25,6 +25,13 @@ class MealAnalysis(Base):
     recommendations = Column(JSONB, nullable=False, server_default=text("'[]'"))
     # Cle de cache (top_food_label, health_goal, imbalances). 30 jours TTL (V10).
     recommendations_hash = Column(String(64))
+    # Tags structures {nutrient, status, delta_pct, target_value, actual_value, unit} (V11).
+    # Liste vide quand le profil utilisateur est incomplet (TDEE non calculable).
+    imbalances = Column(JSONB)
+    # 3 portions (small/medium/large) par item detecte avec macros recalculees (V11).
+    serving_sizes = Column(JSONB)
+    # breakfast/lunch/dinner/snack ; NULL = fallback TDEE/4 (V11).
+    meal_type = Column(Text)
     created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
 
@@ -38,6 +45,10 @@ class MealPlan(Base):
     constraints = Column(JSONB, nullable=False, server_default=text("'{}'"))
     # SHA256 des inputs canonicalises ; cle de cache (V9). Index dedie en BDD.
     inputs_hash = Column(String(64))
+    # Sortie de la boucle DeCRIM-light : full / partial_budget / static_fallback (V11).
+    compliance_status = Column(Text, nullable=False, server_default=text("'full'"))
+    # Strings explicitant les relachements de contraintes (V11).
+    compliance_warnings = Column(ARRAY(Text))
     generated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
 

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -1,0 +1,129 @@
+# Modele de donnees relationnel : adaptations AI-Nutrition
+
+Document destine au livrable PDF MSPR2 numero 8 ("Modele de donnees relationnel documente expliquant les adaptations realisees sur le modele existant").
+
+Le service `MSPR-AI-Nutrition` partage la base PostgreSQL `healthai` avec le reste de la plateforme MSPR (cf. `MSPR-DB`). Trois nouvelles tables et deux enrichissements ont ete ajoutes pour porter les pipelines IA. Les migrations sont versionnees dans `MSPR-DB/migrations/`.
+
+## Migrations concernees
+
+| Version | Fichier | Apport |
+|---------|---------|--------|
+| V8 | `V8__ai_nutrition_tables.sql` | Creation des 3 tables AI-Nutrition (`meal_analyses`, `meal_plans`, `nutrition_goals`). |
+| V9 | `V9__ai_nutrition_enrichment.sql` | Ajout `nutrition_goals.health_goal` (CHECK), `meal_plans.inputs_hash`, `meal_analyses.recommendations`. |
+| V10 | `V10__meal_analyses_recommendations_hash.sql` | Ajout `meal_analyses.recommendations_hash` + index. |
+| V11 | `V11__ai_nutrition_v11.sql` | Ajout `meal_analyses.imbalances`, `meal_analyses.serving_sizes`, `meal_analyses.meal_type`, `meal_plans.compliance_status` (NOT NULL DEFAULT `'full'`), `meal_plans.compliance_warnings`. |
+
+## Tables ajoutees
+
+### `meal_analyses`
+
+Resultat d'une analyse de photo de repas (endpoint `POST /api/v1/analyze-meal`).
+
+| Colonne | Type | Role |
+|---------|------|------|
+| `id` | `BIGSERIAL PK` | Identifiant. |
+| `user_id` | `BIGINT NOT NULL` | Identifiant opaque issu du JWT (cf. ci-dessous). |
+| `photo_url` | `VARCHAR(500)` | Reserve, non utilise actuellement (la photo n'est pas stockee). |
+| `detected_foods` | `JSONB` | Top-3 aliments avec score : `[{label, confidence, nutrition}]`. |
+| `macros` | `JSONB` | Macros calculees du repas : `{calories, protein_g, carbs_g, fat_g, fiber_g}`. |
+| `confidence_scores` | `JSONB` | Map `label -> score` (HuggingFace). |
+| `recommendations` | `JSONB` | Liste de phrases de recommandations (LLM ou matrice). |
+| `recommendations_hash` | `VARCHAR(64)` | SHA256 hex du tuple `(top_label, health_goal, imbalances triees)`. NULL en mode fallback. |
+| `imbalances` | `JSONB` | (V11) Tags structures `{nutrient, status, delta_pct, target_value, actual_value, unit}`. NULL ou liste vide quand le profil utilisateur est incomplet (TDEE non calculable). |
+| `serving_sizes` | `JSONB` | (V11) 3 portions (`small` / `medium` / `large`) par item detecte avec macros recalculees. Reperes PNNS via le mapping Food-101 -> PNNS. |
+| `meal_type` | `TEXT` | (V11) `breakfast` / `lunch` / `dinner` / `snack`. NULL = fallback TDEE/4 cote app. |
+| `created_at` | `TIMESTAMP` | Date de l'analyse, sert egalement de TTL (30 jours pour le cache). |
+
+Indexes :
+- `idx_meal_analyses_user_id (user_id)` : historique par utilisateur.
+- `idx_meal_analyses_created_at (created_at DESC)` : tri pour la pagination.
+- `idx_meal_analyses_recommendations_hash (recommendations_hash)` : lookup cache LLM.
+
+### `meal_plans`
+
+Plans repas generes par LLM (endpoint `POST /api/v1/generate-meal-plan`).
+
+| Colonne | Type | Role |
+|---------|------|------|
+| `id` | `BIGSERIAL PK` | Identifiant. |
+| `user_id` | `BIGINT NOT NULL` | Identifiant opaque issu du JWT. |
+| `plan` | `JSONB` | Plan complet : `{fallback, days: [{day, meals: [{name, macros, ingredients, est_budget_eur, prep_time_min}]}]}`. |
+| `objective` | `VARCHAR(100)` | Objectif sante effectif (`weight_loss`, `muscle_gain`, `balance`, `sport_performance`). |
+| `constraints` | `JSONB` | Contraintes canonicalisees (regime, allergies triees, budget, duree, calories cible). |
+| `inputs_hash` | `VARCHAR(64)` | SHA256 hex de `constraints` + user_id, cle de cache (TTL 7 jours). |
+| `compliance_status` | `TEXT NOT NULL DEFAULT 'full'` | (V11) Sortie de la boucle DeCRIM-light : `full`, `partial_budget` ou `static_fallback`. Default `full` pour la retro-compatibilite des lignes pre-V11. |
+| `compliance_warnings` | `TEXT[]` | (V11) Strings explicitant les relachements de contraintes (ex. budget depasse). NULL ou tableau vide quand `compliance_status = 'full'`. |
+| `generated_at` | `TIMESTAMP` | Date de generation. |
+
+Indexes :
+- `idx_meal_plans_user_id (user_id)` : historique par utilisateur.
+- `idx_meal_plans_generated_at (generated_at DESC)` : tri pour la pagination.
+- `idx_meal_plans_inputs_hash (inputs_hash)` : lookup cache LLM.
+
+### `nutrition_goals`
+
+Profil nutritionnel de l'utilisateur (endpoints `GET` / `PUT /api/v1/nutrition-goals/me`).
+
+| Colonne | Type | Role |
+|---------|------|------|
+| `user_id` | `BIGINT PK` | Une ligne par utilisateur (PK = user_id, pas d'ID synthetique). |
+| `calories_target` | `INTEGER` | Apport quotidien cible. |
+| `protein_g` / `carbs_g` / `fat_g` | `DECIMAL(8, 2)` | Macros cibles. |
+| `allergies` | `TEXT[]` | Liste declarative. |
+| `diet_type` | `VARCHAR(50)` | `omnivore`, `vegetarien`, `vegan`, `sans_gluten` (validation cote app via Pydantic). |
+| `health_goal` | `VARCHAR(30)` | CHECK in `('weight_loss', 'muscle_gain', 'balance', 'sport_performance')`. NULL = `balance` par defaut. |
+
+## Choix d'architecture
+
+### Pas de cle etrangere vers `users`
+
+La table `users` heritee du schema initial (V1) a ete supprimee en V7. Les datasets sources de l'ETL sont anonymises et n'ont pas d'identifiant utilisateur commun. La verite des comptes vit desormais dans le service `MSPR-AUTH` (PostgreSQL dedie sur le port 5433, schema better-auth).
+
+`user_id` reste donc un `BIGINT` opaque dans les 3 tables AI-Nutrition. Il est extrait du JWT decode localement par AI-Nutrition (HS256 partage avec MSPR-AUTH via `BETTER_AUTH_SECRET`). L'integrite est garantie par le secret partage : un JWT mal signe est rejete avant toute requete BDD.
+
+Aucune contrainte d'integrite referentielle n'est posee. C'est un compromis assume :
+- avantage : les services AI-Nutrition et AUTH peuvent evoluer independamment, pas de couplage transversal sur la BDD.
+- limite : un user supprime cote AUTH laisse des lignes orphelines en BDD AI-Nutrition. Acceptable puisque l'API filtre toujours par `user_id` issu du JWT (un utilisateur supprime ne peut plus s'authentifier).
+
+### `nutrition_goals.user_id` comme cle primaire
+
+Une seule ligne par utilisateur. La PK directement sur `user_id` evite un ID synthetique inutile et permet l'upsert via `INSERT ... ON CONFLICT (user_id) DO UPDATE`.
+
+### Hashes de cache (`inputs_hash`, `recommendations_hash`)
+
+Deux caches applicatifs sont implementes en BDD (pas de Redis ni autre store).
+
+- **`meal_plans.inputs_hash`** (V9) : SHA256 hex (64 caracteres) du JSON canonicalise des inputs (`PlanInputs` triee : objective, duration_days, diet_type, allergies triees, budget_per_day, calories_target, user_id). TTL 7 jours. Index dedie pour le lookup.
+- **`meal_analyses.recommendations_hash`** (V10) : SHA256 hex du tuple `(top_food_label, health_goal, imbalances triees)`. Cache global (sans user_id) car la recommandation depend uniquement du contexte nutritionnel, pas de l'utilisateur. TTL 30 jours, applique cote SELECT (`created_at > NOW() - INTERVAL`).
+
+NULL = recommandation issue du fallback matrice. On ne cache pas le fallback : un appel ulterieur retentera Ollama.
+
+Race condition assumee : deux requetes concurrentes avec le meme hash peuvent toutes deux declencher un appel LLM avant que la premiere n'ecrive. La seconde ecrasera juste l'entree avec une valeur equivalente. Volume actuel trop faible pour justifier un `INSERT ON CONFLICT`.
+
+### Champ `health_goal` enrichi en V9
+
+Initialement `nutrition_goals` n'avait pas d'objectif sante : seulement les cibles macros. Pour resoudre l'objectif applicable a `/generate-meal-plan` sans demander a l'utilisateur a chaque appel, on stocke le choix dans le profil. `NULL` est traite comme `balance` cote app, ce qui permet de creer un profil minimal sans choisir d'objectif.
+
+La contrainte CHECK SQL bloque les valeurs incoherentes en BDD au cas ou l'API serait court-circuitee.
+
+### Pas de schema dedie
+
+Les 3 tables coexistent dans le schema `public` avec les tables ETL existantes (`exercises`, `nutrition_entries`, etc.). Aucun isolation cote BDD : chaque service a son propre utilisateur applicatif ou non, mais toutes les migrations sont centralisees dans `MSPR-DB`. C'est coherent avec le pattern adopte sur la plateforme et ca permet les jointures (le service utilise `nutrition_entries` pour le lookup nutritionnel).
+
+### JSONB pour les structures variables
+
+`detected_foods`, `macros`, `plan`, `constraints` sont des structures dont le schema peut evoluer (ajout de nouveaux champs au gre des iterations LLM ou des extensions du modele). `JSONB` permet ces evolutions sans migration. Tradeoff connu : pas de validation SQL des sous-structures, c'est Pydantic cote application qui assure le contrat.
+
+## Liens avec les endpoints
+
+| Endpoint | Tables touchees |
+|----------|-----------------|
+| `POST /api/v1/analyze-meal` | Lit `nutrition_entries` (lookup), `nutrition_goals` (profil). Ecrit `meal_analyses`. Lit/ecrit `meal_analyses` pour le cache de recommandations. |
+| `GET /api/v1/meal-analyses/me` | Lit `meal_analyses` (filtre `user_id`, tri `created_at DESC`, pagination). |
+| `POST /api/v1/generate-meal-plan` | Lit `nutrition_goals` (profil). Lit/ecrit `meal_plans` pour le cache (filtre `user_id` + `inputs_hash`, TTL 7j). |
+| `GET /api/v1/meal-plans/me` | Lit `meal_plans` (filtre `user_id`, tri `generated_at DESC`, pagination). |
+| `GET` / `PUT /api/v1/nutrition-goals/me` | Lit / upsert `nutrition_goals`. |
+
+## Schema applicatif
+
+Cote Python, les 3 tables sont mappees via SQLAlchemy 2.0 dans `app/db/models.py`. Les schemas Pydantic v2 sont declares dans `app/models/schemas.py` et exposes par FastAPI dans l'OpenAPI generee.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,13 @@ from testcontainers.postgres import PostgresContainer
 
 MIGRATIONS_DIR = Path(os.environ.get("MIGRATIONS_DIR", "/migrations"))
 MIGRATION_PATTERN = re.compile(r"^V(\d+)__.*\.sql$")
-MAX_MIGRATION_VERSION = 10  # AC issue 26 : V1 a V10
+MAX_MIGRATION_VERSION = 11  # PRD #45 slice 1 : V11 ajoute imbalances, serving_sizes, meal_type, compliance_status, compliance_warnings
 
 TEST_AUTH_SECRET = "test-secret-not-for-prod-do-not-use"
 TEST_OLLAMA_HOST = "http://ollama-test:11434"
 
 # Tables truncatees avant chaque test (isolation function-scope).
-# nutrition_entries vient de l'ETL, le reste est cree par V8/V9.
+# nutrition_entries vient de l'ETL, le reste est cree par V8/V9/V11.
 _TRUNCATE_TABLES = [
     "meal_analyses",
     "meal_plans",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ TEST_AUTH_SECRET = "test-secret-not-for-prod-do-not-use"
 TEST_OLLAMA_HOST = "http://ollama-test:11434"
 
 # Tables truncatees avant chaque test (isolation function-scope).
-# nutrition_entries vient de l'ETL, le reste est cree par V8/V9/V11.
+# nutrition_entries vient de l'ETL, le reste est cree en V8 puis enrichi V9/V10/V11.
 _TRUNCATE_TABLES = [
     "meal_analyses",
     "meal_plans",
@@ -45,7 +45,7 @@ def _ordered_migrations() -> list[Path]:
 
 @pytest.fixture(scope="session")
 def pg_container() -> Generator[PostgresContainer, None, None]:
-    """Spawn un PostgreSQL 17 ephemere et joue les migrations V1 a V9."""
+    """Spawn un PostgreSQL 17 ephemere et joue les migrations jusqu'a MAX_MIGRATION_VERSION."""
     container = PostgresContainer("postgres:17-alpine", driver="psycopg2")
     container.start()
     try:

--- a/tests/test_models_v11_fields.py
+++ b/tests/test_models_v11_fields.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+# Verifie que les colonnes ajoutees par MSPR-DB V11 (slice 1 du PRD #45) sont
+# exposees par les ORM et persistees correctement (insert -> commit -> re-read).
+
+from sqlalchemy.orm import Session
+
+from app.db.models import MealAnalysis, MealPlan
+
+
+def test_meal_analysis_persists_v11_fields(db_session: Session) -> None:
+    imbalances = [
+        {
+            "nutrient": "protein",
+            "status": "deficit",
+            "delta_pct": -25.0,
+            "target_value": 30.0,
+            "actual_value": 22.5,
+            "unit": "g",
+        },
+    ]
+    serving_sizes = [
+        {
+            "label": "small",
+            "grams": 120,
+            "macros": {"calories": 240, "protein_g": 12, "carbs_g": 30, "fat_g": 8},
+        },
+        {
+            "label": "medium",
+            "grams": 200,
+            "macros": {"calories": 400, "protein_g": 20, "carbs_g": 50, "fat_g": 14},
+        },
+        {
+            "label": "large",
+            "grams": 300,
+            "macros": {"calories": 600, "protein_g": 30, "carbs_g": 75, "fat_g": 20},
+        },
+    ]
+
+    analysis = MealAnalysis(
+        user_id=42,
+        photo_url="https://example.test/p.jpg",
+        detected_foods=[{"label": "pizza", "score": 0.85}],
+        macros={"calories": 400, "protein_g": 20},
+        confidence_scores={"pizza": 0.85},
+        imbalances=imbalances,
+        serving_sizes=serving_sizes,
+        meal_type="lunch",
+    )
+    db_session.add(analysis)
+    db_session.commit()
+
+    fetched = db_session.query(MealAnalysis).filter_by(user_id=42).one()
+    assert fetched.imbalances == imbalances
+    assert fetched.serving_sizes == serving_sizes
+    assert fetched.meal_type == "lunch"
+
+
+def test_meal_analysis_v11_fields_default_to_null(db_session: Session) -> None:
+    # Les 3 colonnes V11 sur meal_analyses sont nullable. Quand on insere sans
+    # les renseigner, elles doivent rester NULL (pas de default applicatif).
+    analysis = MealAnalysis(user_id=7)
+    db_session.add(analysis)
+    db_session.commit()
+
+    fetched = db_session.query(MealAnalysis).filter_by(user_id=7).one()
+    assert fetched.imbalances is None
+    assert fetched.serving_sizes is None
+    assert fetched.meal_type is None
+
+
+def test_meal_plan_persists_v11_fields(db_session: Session) -> None:
+    warnings = ["Budget journalier depasse de 1.20 EUR le mardi"]
+
+    plan = MealPlan(
+        user_id=99,
+        plan={"days": []},
+        objective="weight_loss",
+        constraints={"allergies": ["peanut"], "diet": "vegan", "budget_eur_per_day": 8.0},
+        compliance_status="partial_budget",
+        compliance_warnings=warnings,
+    )
+    db_session.add(plan)
+    db_session.commit()
+
+    fetched = db_session.query(MealPlan).filter_by(user_id=99).one()
+    assert fetched.compliance_status == "partial_budget"
+    assert fetched.compliance_warnings == warnings
+
+
+def test_meal_plan_compliance_status_defaults_to_full(db_session: Session) -> None:
+    # V11 : compliance_status TEXT NOT NULL DEFAULT 'full'. Insertion sans la
+    # colonne doit retourner 'full' apres flush + refresh (default cote BDD).
+    plan = MealPlan(user_id=11)
+    db_session.add(plan)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    assert plan.compliance_status == "full"
+    assert plan.compliance_warnings is None


### PR DESCRIPTION
Closes #46

Slice 1 du PRD #45. Persiste les nouveaux champs metier (imbalances, serving_sizes, meal_type, compliance_status, compliance_warnings) ajoutes par la migration V11 cote MSPR-DB.

## Summary
- ORM `MealAnalysis` : `imbalances` (JSONB), `serving_sizes` (JSONB), `meal_type` (TEXT).
- ORM `MealPlan` : `compliance_status` (TEXT NOT NULL DEFAULT `'full'`), `compliance_warnings` (TEXT[]).
- Tests d'ecriture / lecture via SQLAlchemy + testcontainers (`tests/test_models_v11_fields.py`, 4 cas).
- `tests/conftest.py` : `MAX_MIGRATION_VERSION` passe de 10 a 11.
- `docs/data_model.md` : version commitee, enrichie des entrees V11.

## Depends on
- whitefoxxyt/MSPR-HealthAI-Coach-BDD#7 (V11 SQL) doit etre merge avant que les tests passent en CI sur la BDD partagee.

## Test plan
- [x] `pytest tests/test_models_v11_fields.py` -> 4 passed.
- [x] Suite complete `pytest -m 'not slow'` -> 249 passed (aucune regression).
- [ ] Verifier que la PR MSPR-DB#7 est merge avant la merge de cette PR.
- [ ] Apres merge V11 : `docker compose down -v && up` en local pour valider l'application en froid.