### PR TITLE
[Slice 2] Module nutrition_engine + endpoint GET /me/macros

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,15 @@
 from pydantic_settings import BaseSettings
 
+# Reperes ANSES (rapport "Actualisation des reperes du PNNS", 2016 ;
+# avis 2017-SA-0142 sur les recommandations alimentaires).
+# Utilises par nutrition_engine et imbalance_detector pour calculer les
+# desequilibres macro a partir d'une cible personnalisee (TDEE) plutot que
+# de seuils en pourcentage figes.
+RNP_PROTEIN_G_PER_KG = 0.83  # apport recommande, en g/kg de poids corporel/j
+RNP_FIBER_G_PER_DAY = 30  # cible journaliere fibres alimentaires, en g/j
+RNP_AGS_PERCENT_OF_AET_MAX = 0.12  # plafond acides gras satures, en % AET
+RNP_TOTAL_SUGARS_G_MAX = 100  # plafond sucres totaux, en g/j
+
 
 class Settings(BaseSettings):
     db_host: str = "mspr-healthai-db"

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -52,3 +52,9 @@ class NutritionGoal(Base):
     allergies = Column(ARRAY(String))
     diet_type = Column(String(50))
     health_goal = Column(String(30))
+    # Biometrie (V12) pour le calcul TDEE via Mifflin-St Jeor.
+    gender = Column(String(10))
+    age = Column(Integer)
+    weight_kg = Column(Numeric(5, 2))
+    height_cm = Column(Numeric(5, 2))
+    activity_level = Column(String(20))

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from app.limiter import limiter
-from app.routers import health, meal_analysis, meal_plan, nutrition_goals
+from app.routers import health, me, meal_analysis, meal_plan, nutrition_goals
 
 API_DESCRIPTION = """
 Micro-service d'analyse nutritionnelle et de generation de plans repas par IA, partie de la plateforme MSPR HealthAI Coach.
@@ -59,3 +59,4 @@ app.include_router(health.router)
 app.include_router(meal_analysis.router, prefix="/api/v1")
 app.include_router(meal_plan.router, prefix="/api/v1")
 app.include_router(nutrition_goals.router, prefix="/api/v1")
+app.include_router(me.router, prefix="/api/v1")

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -15,6 +15,19 @@ class HealthGoal(str, Enum):
     sport_performance = "sport_performance"
 
 
+class Gender(str, Enum):
+    male = "male"
+    female = "female"
+
+
+class ActivityLevel(str, Enum):
+    sedentary = "sedentary"
+    light = "light"
+    moderate = "moderate"
+    active = "active"
+    very_active = "very_active"
+
+
 # MealAnalysis
 
 class MealAnalysisItem(BaseModel):
@@ -65,12 +78,35 @@ class NutritionGoalRequest(BaseModel):
     fat_g: Decimal | None = None
     allergies: list[str] = []
     diet_type: str | None = None
+    # Biometrie (V12) : entree pour le calcul du TDEE par nutrition_engine.
+    gender: Gender | None = None
+    age: int | None = None
+    weight_kg: Decimal | None = None
+    height_cm: Decimal | None = None
+    activity_level: ActivityLevel | None = None
 
 
 class NutritionGoalResponse(NutritionGoalRequest):
     user_id: int
 
     model_config = {"from_attributes": True}
+
+
+# GET /me/macros : cible journaliere derivee du profil + objectif sante (slice 2 PRD #45).
+
+
+class MacroTargetsView(BaseModel):
+    calories: float
+    protein_g: float
+    carbs_g: float
+    fat_g: float
+
+
+class MeMacrosResponse(BaseModel):
+    profile_completion_required: bool
+    missing_fields: list[str] = []
+    tdee: float | None = None
+    macros: MacroTargetsView | None = None
 
 
 # Plans repas fallback (issue NUT-8). Cf. POST /api/v1/generate-meal-plan.

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.schemas import HealthGoal, MacroTargetsView, MeMacrosResponse
+from app.services import jwt_decoder, profile_service
+from app.services.nutrition_engine import (
+    IncompleteProfile,
+    build_user_profile,
+    compute_macro_targets,
+    compute_tdee,
+)
+
+router = APIRouter(prefix="/me")
+
+
+def _user_id_from_auth(authorization: str | None) -> int:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authorization header invalide.")
+    identity = jwt_decoder.decode(authorization.removeprefix("Bearer "))
+    try:
+        return int(identity.user_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Sujet JWT invalide.") from exc
+
+
+_DESCRIPTION = """
+Retourne la cible journaliere de l'utilisateur authentifie (TDEE et macros).
+
+Le TDEE est calcule via la formule de Mifflin-St Jeor a partir des champs
+biometriques du profil (`gender`, `age`, `weight_kg`, `height_cm`, `activity_level`)
+et de l'objectif sante (`health_goal`). La repartition macro suit l'objectif :
+
+- `balance` : 50 % glucides, 20 % proteines, 30 % lipides
+- `weight_loss` : 40 / 30 / 30
+- `muscle_gain` : 45 / 30 / 25
+- `sport_performance` : 55 / 20 / 25
+
+Quand un champ biometrique est manquant, la reponse renseigne
+`profile_completion_required=true` et liste les `missing_fields` plutot que de
+retourner une cible degradee.
+
+**Authentification** : header `Authorization: Bearer <jwt>` requis.
+"""
+
+
+@router.get(
+    "/macros",
+    response_model=MeMacrosResponse,
+    tags=["Profil"],
+    summary="Cible journaliere TDEE et macros pour l'utilisateur",
+    description=_DESCRIPTION,
+    responses={
+        200: {"description": "Cible journaliere ou liste des champs manquants."},
+        401: {"description": "JWT manquant, malforme ou invalide."},
+    },
+)
+def get_my_macros(
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> MeMacrosResponse:
+    user_id = _user_id_from_auth(authorization)
+    record = profile_service.get_profile(user_id, db)
+
+    profile_or_missing = build_user_profile(record)
+    if isinstance(profile_or_missing, IncompleteProfile):
+        return MeMacrosResponse(
+            profile_completion_required=True,
+            missing_fields=profile_or_missing.missing_fields,
+        )
+
+    # health_goal n'est pas dans la biometrie ; on retombe sur balance par defaut
+    # plutot que d'exiger une valeur explicite (objectif sante = preference, pas
+    # condition de calcul du TDEE).
+    health_goal = (
+        HealthGoal(record.health_goal)
+        if record is not None and record.health_goal is not None
+        else HealthGoal.balance
+    )
+    tdee = compute_tdee(profile_or_missing)
+    macros = compute_macro_targets(tdee, health_goal)
+
+    return MeMacrosResponse(
+        profile_completion_required=False,
+        missing_fields=[],
+        tdee=tdee,
+        macros=MacroTargetsView(
+            calories=macros.calories,
+            protein_g=macros.protein_g,
+            carbs_g=macros.carbs_g,
+            fat_g=macros.fat_g,
+        ),
+    )

--- a/app/services/nutrition_engine.py
+++ b/app/services/nutrition_engine.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from app.models.schemas import ActivityLevel, Gender, HealthGoal
+
+
+@dataclass(frozen=True)
+class UserProfile:
+    gender: Gender
+    age: int
+    weight_kg: float
+    height_cm: float
+    activity_level: ActivityLevel
+
+
+_ACTIVITY_FACTORS: dict[ActivityLevel, float] = {
+    ActivityLevel.sedentary: 1.2,
+    ActivityLevel.light: 1.375,
+    ActivityLevel.moderate: 1.55,
+    ActivityLevel.active: 1.725,
+    ActivityLevel.very_active: 1.9,
+}
+
+
+# Repartition (% glucides, % proteines, % lipides) par objectif sante.
+# - balance         : reperes ANSES generaux (50/20/30)
+# - weight_loss     : proteines elevees pour preserver la masse maigre
+# - muscle_gain     : surplus glucidique modere + proteines elevees
+# - sport_performance : glucides eleves pour la resynthese du glycogene
+_MACRO_SPLITS: dict[HealthGoal, tuple[float, float, float]] = {
+    HealthGoal.balance: (0.50, 0.20, 0.30),
+    HealthGoal.weight_loss: (0.40, 0.30, 0.30),
+    HealthGoal.muscle_gain: (0.45, 0.30, 0.25),
+    HealthGoal.sport_performance: (0.55, 0.20, 0.25),
+}
+
+
+class MealType(str, Enum):
+    breakfast = "breakfast"
+    lunch = "lunch"
+    dinner = "dinner"
+    snack = "snack"
+
+
+# Reperes PNNS / pratique courante : repartition energetique sur la journee.
+_MEAL_QUOTAS: dict[MealType, float] = {
+    MealType.breakfast: 0.25,
+    MealType.lunch: 0.35,
+    MealType.dinner: 0.30,
+    MealType.snack: 0.10,
+}
+
+
+@dataclass(frozen=True)
+class MacroTargets:
+    calories: float
+    protein_g: float
+    carbs_g: float
+    fat_g: float
+
+
+@dataclass(frozen=True)
+class MealTargets:
+    calories: float
+    protein_g: float
+    carbs_g: float
+    fat_g: float
+
+
+@dataclass(frozen=True)
+class IncompleteProfile:
+    missing_fields: list[str]
+
+
+_PROFILE_FIELDS: tuple[str, ...] = (
+    "gender",
+    "age",
+    "weight_kg",
+    "height_cm",
+    "activity_level",
+)
+
+
+def compute_bmr(profile: UserProfile) -> float:
+    # Mifflin-St Jeor :
+    #   homme  : 10*kg + 6.25*cm - 5*age + 5
+    #   femme  : 10*kg + 6.25*cm - 5*age - 161
+    base = 10.0 * profile.weight_kg + 6.25 * profile.height_cm - 5.0 * profile.age
+    if profile.gender is Gender.male:
+        return base + 5.0
+    return base - 161.0
+
+
+def compute_tdee(profile: UserProfile) -> float:
+    return compute_bmr(profile) * _ACTIVITY_FACTORS[profile.activity_level]
+
+
+def compute_macro_targets(tdee: float, health_goal: HealthGoal) -> MacroTargets:
+    carbs_pct, protein_pct, fat_pct = _MACRO_SPLITS[health_goal]
+    # 4 kcal/g pour proteines et glucides, 9 kcal/g pour lipides.
+    return MacroTargets(
+        calories=tdee,
+        protein_g=tdee * protein_pct / 4.0,
+        carbs_g=tdee * carbs_pct / 4.0,
+        fat_g=tdee * fat_pct / 9.0,
+    )
+
+
+def build_user_profile(source: object | None) -> UserProfile | IncompleteProfile:
+    # Source = NutritionGoal ORM ou tout objet exposant les 5 attributs profil.
+    # Champ manquant = absent ou explicitement None ; on agglome dans
+    # missing_fields pour permettre au front de pointer ce qu'il manque.
+    if source is None:
+        return IncompleteProfile(missing_fields=list(_PROFILE_FIELDS))
+    missing = [name for name in _PROFILE_FIELDS if getattr(source, name, None) is None]
+    if missing:
+        return IncompleteProfile(missing_fields=missing)
+    return UserProfile(
+        gender=Gender(source.gender),
+        age=int(source.age),
+        weight_kg=float(source.weight_kg),
+        height_cm=float(source.height_cm),
+        activity_level=ActivityLevel(source.activity_level),
+    )
+
+
+def compute_meal_targets(
+    profile: UserProfile,
+    meal_type: MealType | None,
+    health_goal: HealthGoal,
+) -> MealTargets:
+    # Fallback : meal_type absent -> repartition uniforme sur 4 prises.
+    quota = _MEAL_QUOTAS[meal_type] if meal_type is not None else 0.25
+    daily = compute_macro_targets(compute_tdee(profile), health_goal)
+    return MealTargets(
+        calories=daily.calories * quota,
+        protein_g=daily.protein_g * quota,
+        carbs_g=daily.carbs_g * quota,
+        fat_g=daily.fat_g * quota,
+    )

--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from enum import Enum
+
 from sqlalchemy.orm import Session
 
 from app.db.models import NutritionGoal
@@ -27,9 +29,10 @@ def upsert_profile(
 
 
 def _normalize(fields: dict) -> dict:
-    # Pydantic serialise l'enum HealthGoal en str via model_dump(mode="python") par defaut,
-    # mais on stocke la valeur de l'enum (str) dans la colonne VARCHAR(30).
-    health_goal = fields.get("health_goal")
-    if health_goal is not None and hasattr(health_goal, "value"):
-        return {**fields, "health_goal": health_goal.value}
-    return fields
+    # Pydantic serialise les enums en instances via model_dump(mode="python") par defaut.
+    # On extrait .value pour stocker le string brut dans les colonnes VARCHAR
+    # (health_goal, gender, activity_level, diet_type, ...).
+    return {
+        key: value.value if isinstance(value, Enum) else value
+        for key, value in fields.items()
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from testcontainers.postgres import PostgresContainer
 
 MIGRATIONS_DIR = Path(os.environ.get("MIGRATIONS_DIR", "/migrations"))
 MIGRATION_PATTERN = re.compile(r"^V(\d+)__.*\.sql$")
-MAX_MIGRATION_VERSION = 10  # AC issue 26 : V1 a V10
+MAX_MIGRATION_VERSION = 12  # V11 (slice 1, PRD #45) + V12 (slice 2, biometrie)
 
 TEST_AUTH_SECRET = "test-secret-not-for-prod-do-not-use"
 TEST_OLLAMA_HOST = "http://ollama-test:11434"

--- a/tests/test_me_macros_api.py
+++ b/tests/test_me_macros_api.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+from tests.conftest import TEST_AUTH_SECRET
+
+
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "better_auth_secret", TEST_AUTH_SECRET)
+
+
+@pytest.fixture
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _full_profile_payload() -> dict:
+    return {
+        "health_goal": "balance",
+        "gender": "male",
+        "age": 30,
+        "weight_kg": 80,
+        "height_cm": 180,
+        "activity_level": "moderate",
+    }
+
+
+def test_get_macros_with_complete_profile_returns_tdee_and_macros(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=42)
+    auth = {"Authorization": f"Bearer {token}"}
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json=_full_profile_payload(),
+        headers=auth,
+    )
+
+    response = client.get("/api/v1/me/macros", headers=auth)
+
+    assert response.status_code == 200
+    body = response.json()
+    # Mifflin-St Jeor homme 30 ans, 80 kg, 180 cm -> BMR 1780 ; moderate -> TDEE 2759.
+    # Repartition balance : 50 % glucides, 20 % proteines, 30 % lipides.
+    assert body["profile_completion_required"] is False
+    assert body["missing_fields"] == []
+    assert body["tdee"] == pytest.approx(2759.0)
+    macros = body["macros"]
+    assert macros["calories"] == pytest.approx(2759.0)
+    assert macros["protein_g"] == pytest.approx(2759.0 * 0.20 / 4.0)
+    assert macros["carbs_g"] == pytest.approx(2759.0 * 0.50 / 4.0)
+    assert macros["fat_g"] == pytest.approx(2759.0 * 0.30 / 9.0)
+
+
+def test_get_macros_without_profile_returns_completion_required(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=99)
+
+    response = client.get(
+        "/api/v1/me/macros",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["profile_completion_required"] is True
+    assert set(body["missing_fields"]) == {
+        "gender",
+        "age",
+        "weight_kg",
+        "height_cm",
+        "activity_level",
+    }
+    assert body["tdee"] is None
+    assert body["macros"] is None
+
+
+def test_get_macros_with_partial_profile_lists_only_missing_fields(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    token = valid_jwt(user_id=11)
+    auth = {"Authorization": f"Bearer {token}"}
+    # Profil avec health_goal + age + height seulement.
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json={"health_goal": "weight_loss", "age": 28, "height_cm": 170},
+        headers=auth,
+    )
+
+    response = client.get("/api/v1/me/macros", headers=auth)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["profile_completion_required"] is True
+    assert set(body["missing_fields"]) == {"gender", "weight_kg", "activity_level"}
+    assert body["tdee"] is None
+
+
+def test_get_macros_without_authorization_returns_401(client: TestClient) -> None:
+    response = client.get("/api/v1/me/macros")
+    assert response.status_code == 401
+
+
+def test_get_macros_with_invalid_jwt_returns_401(client: TestClient) -> None:
+    response = client.get(
+        "/api/v1/me/macros",
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert response.status_code == 401
+
+
+def test_get_macros_isolates_users(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+) -> None:
+    alice = valid_jwt(user_id=100)
+    bob = valid_jwt(user_id=200)
+    # Alice configure un profil complet ; Bob non.
+    client.put(
+        "/api/v1/nutrition-goals/me",
+        json=_full_profile_payload(),
+        headers={"Authorization": f"Bearer {alice}"},
+    )
+
+    bob_response = client.get(
+        "/api/v1/me/macros",
+        headers={"Authorization": f"Bearer {bob}"},
+    )
+
+    assert bob_response.status_code == 200
+    assert bob_response.json()["profile_completion_required"] is True

--- a/tests/unit/test_nutrition_engine.py
+++ b/tests/unit/test_nutrition_engine.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.schemas import HealthGoal
+from app.services.nutrition_engine import (
+    ActivityLevel,
+    Gender,
+    IncompleteProfile,
+    MealType,
+    UserProfile,
+    build_user_profile,
+    compute_bmr,
+    compute_macro_targets,
+    compute_meal_targets,
+    compute_tdee,
+)
+
+
+def test_compute_bmr_male_mifflin_st_jeor_textbook_case() -> None:
+    # Mifflin-St Jeor homme : 10*80 + 6.25*180 - 5*30 + 5 = 1780 kcal/j.
+    profile = UserProfile(
+        gender=Gender.male,
+        age=30,
+        weight_kg=80.0,
+        height_cm=180.0,
+        activity_level=ActivityLevel.moderate,
+    )
+
+    assert compute_bmr(profile) == pytest.approx(1780.0)
+
+
+def test_compute_bmr_female_mifflin_st_jeor_textbook_case() -> None:
+    # Mifflin-St Jeor femme : 10*60 + 6.25*165 - 5*25 - 161 = 1345.25 kcal/j.
+    profile = UserProfile(
+        gender=Gender.female,
+        age=25,
+        weight_kg=60.0,
+        height_cm=165.0,
+        activity_level=ActivityLevel.light,
+    )
+
+    assert compute_bmr(profile) == pytest.approx(1345.25)
+
+
+@pytest.mark.parametrize(
+    ("activity", "expected_tdee"),
+    [
+        # BMR homme reference = 1780 kcal/j (cf. test compute_bmr male).
+        (ActivityLevel.sedentary, 1780.0 * 1.2),
+        (ActivityLevel.light, 1780.0 * 1.375),
+        (ActivityLevel.moderate, 1780.0 * 1.55),
+        (ActivityLevel.active, 1780.0 * 1.725),
+        (ActivityLevel.very_active, 1780.0 * 1.9),
+    ],
+)
+def test_compute_tdee_applies_activity_factor(
+    activity: ActivityLevel, expected_tdee: float
+) -> None:
+    profile = UserProfile(
+        gender=Gender.male,
+        age=30,
+        weight_kg=80.0,
+        height_cm=180.0,
+        activity_level=activity,
+    )
+
+    assert compute_tdee(profile) == pytest.approx(expected_tdee)
+
+
+def test_compute_macro_targets_balance_uses_50_20_30_split() -> None:
+    # health_goal=balance : 50 % glucides, 20 % proteines, 30 % lipides.
+    # TDEE 2000 kcal :
+    #   prot  = 0.20 * 2000 / 4 = 100 g
+    #   carbs = 0.50 * 2000 / 4 = 250 g
+    #   fat   = 0.30 * 2000 / 9 ~= 66.67 g
+    macros = compute_macro_targets(tdee=2000.0, health_goal=HealthGoal.balance)
+
+    assert macros.calories == pytest.approx(2000.0)
+    assert macros.protein_g == pytest.approx(100.0)
+    assert macros.carbs_g == pytest.approx(250.0)
+    assert macros.fat_g == pytest.approx(2000.0 * 0.30 / 9.0)
+
+
+@pytest.mark.parametrize(
+    ("health_goal", "carbs_pct", "protein_pct", "fat_pct"),
+    [
+        (HealthGoal.balance, 0.50, 0.20, 0.30),
+        (HealthGoal.weight_loss, 0.40, 0.30, 0.30),
+        (HealthGoal.muscle_gain, 0.45, 0.30, 0.25),
+        (HealthGoal.sport_performance, 0.55, 0.20, 0.25),
+    ],
+)
+def test_compute_macro_targets_uses_distinct_splits_per_goal(
+    health_goal: HealthGoal,
+    carbs_pct: float,
+    protein_pct: float,
+    fat_pct: float,
+) -> None:
+    tdee = 2400.0
+    macros = compute_macro_targets(tdee=tdee, health_goal=health_goal)
+
+    assert macros.calories == pytest.approx(tdee)
+    assert macros.protein_g == pytest.approx(tdee * protein_pct / 4.0)
+    assert macros.carbs_g == pytest.approx(tdee * carbs_pct / 4.0)
+    assert macros.fat_g == pytest.approx(tdee * fat_pct / 9.0)
+
+
+def test_compute_meal_targets_breakfast_applies_25_pct_quota() -> None:
+    profile = UserProfile(
+        gender=Gender.male,
+        age=30,
+        weight_kg=80.0,
+        height_cm=180.0,
+        activity_level=ActivityLevel.moderate,
+    )
+    # TDEE = 1780 * 1.55 = 2759 kcal/j ; breakfast = 25 % -> 689.75 kcal cible.
+    # Repartition balance sur la part repas : 50 % glucides, 20 % prot, 30 % lip.
+    daily_kcal = 1780.0 * 1.55
+    quota = 0.25
+
+    targets = compute_meal_targets(
+        profile=profile,
+        meal_type=MealType.breakfast,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert targets.calories == pytest.approx(daily_kcal * quota)
+    assert targets.protein_g == pytest.approx(daily_kcal * quota * 0.20 / 4.0)
+    assert targets.carbs_g == pytest.approx(daily_kcal * quota * 0.50 / 4.0)
+    assert targets.fat_g == pytest.approx(daily_kcal * quota * 0.30 / 9.0)
+
+
+@pytest.mark.parametrize(
+    ("meal_type", "expected_quota"),
+    [
+        (MealType.breakfast, 0.25),
+        (MealType.lunch, 0.35),
+        (MealType.dinner, 0.30),
+        (MealType.snack, 0.10),
+    ],
+)
+def test_compute_meal_targets_applies_quota_per_meal_type(
+    meal_type: MealType, expected_quota: float
+) -> None:
+    profile = UserProfile(
+        gender=Gender.male,
+        age=30,
+        weight_kg=80.0,
+        height_cm=180.0,
+        activity_level=ActivityLevel.moderate,
+    )
+    daily_kcal = 1780.0 * 1.55  # TDEE moderate
+
+    targets = compute_meal_targets(
+        profile=profile,
+        meal_type=meal_type,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert targets.calories == pytest.approx(daily_kcal * expected_quota)
+
+
+def test_meal_quotas_sum_to_100_percent() -> None:
+    # Garde-fou : 25 + 35 + 30 + 10 = 100. Si quelqu'un retouche un quota
+    # en oubliant les autres, ce test casse.
+    from app.services.nutrition_engine import _MEAL_QUOTAS
+
+    assert sum(_MEAL_QUOTAS.values()) == pytest.approx(1.0)
+
+
+def test_compute_meal_targets_falls_back_to_tdee_div_4_when_meal_type_absent() -> None:
+    # Issue 47 : "fallback TDEE/4 si meal_type absent".
+    profile = UserProfile(
+        gender=Gender.male,
+        age=30,
+        weight_kg=80.0,
+        height_cm=180.0,
+        activity_level=ActivityLevel.moderate,
+    )
+    daily_kcal = 1780.0 * 1.55
+
+    targets = compute_meal_targets(
+        profile=profile,
+        meal_type=None,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert targets.calories == pytest.approx(daily_kcal / 4.0)
+
+
+def test_anses_rnp_constants_match_official_values() -> None:
+    # Reperes ANSES (rapport "Actualisation des reperes du PNNS", 2016 ;
+    # avis 2017-SA-0142). Sources figees pour `imbalance_detector` (slice 5).
+    from app import config
+
+    assert config.RNP_PROTEIN_G_PER_KG == 0.83
+    assert config.RNP_FIBER_G_PER_DAY == 30
+    assert config.RNP_AGS_PERCENT_OF_AET_MAX == 0.12
+    assert config.RNP_TOTAL_SUGARS_G_MAX == 100
+
+
+def test_build_user_profile_with_no_source_returns_all_fields_missing() -> None:
+    result = build_user_profile(None)
+
+    assert isinstance(result, IncompleteProfile)
+    assert set(result.missing_fields) == {
+        "gender",
+        "age",
+        "weight_kg",
+        "height_cm",
+        "activity_level",
+    }
+
+
+def test_build_user_profile_with_partial_source_lists_only_missing_fields() -> None:
+    from types import SimpleNamespace
+
+    source = SimpleNamespace(
+        gender="male",
+        age=30,
+        weight_kg=None,
+        height_cm=180.0,
+        activity_level=None,
+    )
+
+    result = build_user_profile(source)
+
+    assert isinstance(result, IncompleteProfile)
+    assert set(result.missing_fields) == {"weight_kg", "activity_level"}
+
+
+def test_build_user_profile_with_complete_source_returns_user_profile() -> None:
+    from types import SimpleNamespace
+
+    source = SimpleNamespace(
+        gender="female",
+        age=25,
+        weight_kg=60.0,
+        height_cm=165.0,
+        activity_level="light",
+    )
+
+    result = build_user_profile(source)
+
+    assert isinstance(result, UserProfile)
+    assert result.gender is Gender.female
+    assert result.age == 25
+    assert result.weight_kg == 60.0
+    assert result.height_cm == 165.0
+    assert result.activity_level is ActivityLevel.light


### PR DESCRIPTION
Closes #47

## Summary
Slice 2 du PRD #45 (mise a niveau AI-Nutrition MSPR2). Ajoute le module profond `nutrition_engine` (pure functions, 100 % coverage) qui calcule le TDEE via Mifflin-St Jeor, derive les macros par objectif sante, et applique les quotas par meal_type (breakfast 25 %, lunch 35 %, dinner 30 %, snack 10 %, fallback TDEE/4). Constantes ANSES placees dans `app/config.py` pour reutilisation par le slice 5 (imbalance_detector).

Nouvel endpoint `GET /api/v1/me/macros` (auth JWT) retournant la cible journaliere ou `profile_completion_required: true` + `missing_fields` si la biometrie est incomplete. `NutritionGoal` etendu avec `gender / age / weight_kg / height_cm / activity_level` (migration V12 cote MSPR-DB).

## Cross-repo
- Migration `V12__nutrition_goals_biometrics.sql` ajoutee dans `/home/arthur/Projects/MSPR/MSPR-DB/migrations/` ; doit etre commitee sur le repo MSPR-DB pour que la stack et la CI soient a jour. Independante de V11 (slice 1, #46).

## Test plan
- [ ] `docker compose --profile test run --rm -v /home/arthur/Projects/MSPR/MSPR-DB/migrations:/migrations:ro tests pytest -m "not slow"` -> 274 passed
- [ ] Coverage `nutrition_engine` = 100 %
- [ ] `ruff check .` clean
- [ ] Verifier que la CI sur master picks up V12 une fois la migration mergee sur MSPR-DB
- [ ] PUT `/api/v1/nutrition-goals/me` accepte les nouveaux champs biometriques (les tests existants nutrition_goals_api restent verts)
- [ ] GET `/api/v1/me/macros` testable via Swagger UI sur `localhost:8001/docs`

## Decisions
- `gender` et `activity_level` deplaces de `nutrition_engine.py` vers `app/models/schemas.py` (evite cycle services -> models). Les enums sont reutilises par `NutritionGoalRequest`.
- `health_goal` defaulte a `balance` cote endpoint si absent, pour ne pas forcer l'utilisateur a definir un objectif avant de voir ses macros (preference vs condition de calcul du TDEE).
- `_user_id_from_auth` duplique cote `me.py` pour suivre la convention deja en place (`nutrition_goals.py`, `meal_analysis.py`). Refacto a faire dans une slice dediee si Arthur le souhaite.