### PR TITLE
[Slice 6] DeCRIM-light retry orchestrator (strategie beta-prime hybride)

### DIFF
--- a/app/services/decrim_retry_orchestrator.py
+++ b/app/services/decrim_retry_orchestrator.py
@@ -84,7 +84,7 @@ async def generate_with_retry(
 
         first = violations[0]
         if first.type in (ViolationType.allergy, ViolationType.diet):
-            meal_idx = first.meal_index or 0
+            meal_idx = first.meal_index if first.meal_index is not None else 0
             key = (first.day, meal_idx)
             if meal_retry_counts.get(key, 0) >= 2:
                 # Garde-fou anti-cycle : la meme position viole encore apres 2

--- a/app/services/decrim_retry_orchestrator.py
+++ b/app/services/decrim_retry_orchestrator.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any
+
+import httpx
+
+from app.config import settings
+from app.models.schemas import FallbackMealPlan, Meal, MealDay, PlanInputs
+from app.services.constraint_validator import (
+    ConstraintSpec,
+    ConstraintViolation,
+    ViolationType,
+    validate as validate_constraints,
+)
+from app.services.fallback_loader import load_fallback_plan
+
+_OLLAMA_TIMEOUT_S = 30.0
+_OLLAMA_MODEL = "gemma3:4b"
+
+_PLAN_PROMPT_TEMPLATE = (
+    "Tu es un nutritionniste. Genere un plan repas JSON pour {duration_days} jours.\n"
+    "Objectif : {objective}.\n"
+    "Regime : {diet_type}.\n"
+    "Allergies a eviter (aucun ingredient ne doit en contenir) : {allergies}.\n"
+    "Budget journalier maximal : {budget}.\n"
+    "Cible calorique journaliere : {calories_target}.\n"
+    "Pour chaque repas : name, macros (calories, protein_g, carbs_g, fat_g),\n"
+    "ingredients (liste), est_budget_eur, prep_time_min. Mets fallback=false."
+)
+
+_MEAL_REGEN_PROMPT_TEMPLATE = (
+    "Ce repas a ete rejete car il contient {ingredient!r}. "
+    "Regenere-le sans {ingredient!r}. "
+    "Respecte le regime {diet_type} et evite ces allergenes : {allergies}. "
+    "Reponds par un seul JSON Meal : name, macros (calories, protein_g, "
+    "carbs_g, fat_g), ingredients (liste), est_budget_eur, prep_time_min."
+)
+
+_DAY_REGEN_PROMPT_TEMPLATE = (
+    "Ce jour depasse le budget de {overflow:.2f} EUR. "
+    "Regenere ce jour sous {budget_max:.2f} EUR. "
+    "Garde {meals_count} repas et respecte le regime {diet_type}. "
+    "Reponds par un seul JSON MealDay : day (entier), meals (liste de Meal "
+    "avec name, macros, ingredients, est_budget_eur, prep_time_min)."
+)
+
+
+class ComplianceStatus(str, Enum):
+    full = "full"
+    partial_budget = "partial_budget"
+    static_fallback = "static_fallback"
+
+
+class InfeasibleConstraintsError(Exception):
+    """Allergies / regime infaisables : meme le plan statique de fallback les viole.
+
+    Le caller (router FastAPI) traduit en HTTP 503.
+    """
+
+
+async def generate_with_retry(
+    inputs: PlanInputs,
+    max_retries: int = 3,
+) -> tuple[FallbackMealPlan, ComplianceStatus]:
+    """Genere un plan repas avec retries DeCRIM-light hybride.
+
+    Strategie :
+    - allergie / regime : retry partiel sur le repas violant uniquement
+    - budget : retry complet du jour qui depasse
+    """
+    spec = _build_constraint_spec(inputs)
+    plan = await _call_for_plan(_build_plan_prompt(inputs))
+
+    # Compteur de retries partiels par (jour, repas) : permet de detecter
+    # un cycle ou la meme position viole encore apres 2 regenerations ciblees.
+    meal_retry_counts: dict[tuple[int, int], int] = {}
+
+    for _ in range(max_retries):
+        violations = validate_constraints(plan, spec)
+        if not violations:
+            return plan, ComplianceStatus.full
+
+        first = violations[0]
+        if first.type in (ViolationType.allergy, ViolationType.diet):
+            meal_idx = first.meal_index or 0
+            key = (first.day, meal_idx)
+            if meal_retry_counts.get(key, 0) >= 2:
+                # Garde-fou anti-cycle : la meme position viole encore apres 2
+                # regenerations ciblees. On bascule en retry complet du plan.
+                plan = await _call_for_plan(_build_plan_prompt(inputs))
+                meal_retry_counts.clear()
+                continue
+            meal_retry_counts[key] = meal_retry_counts.get(key, 0) + 1
+            new_meal = await _call_for_meal(_build_meal_regen_prompt(first, inputs))
+            plan = _replace_meal(plan, first.day, meal_idx, new_meal)
+            continue
+
+        if first.type is ViolationType.budget:
+            new_day = await _call_for_day(_build_day_regen_prompt(plan, first, spec))
+            plan = _replace_day(plan, first.day, new_day)
+            continue
+
+    return _resolve_after_retries(plan, inputs, spec)
+
+
+def _resolve_after_retries(
+    plan: FallbackMealPlan, inputs: PlanInputs, spec: ConstraintSpec
+) -> tuple[FallbackMealPlan, ComplianceStatus]:
+    """Apres epuisement des retries : decide entre full / partial_budget / fallback statique."""
+    remaining = validate_constraints(plan, spec)
+    if not remaining:
+        return plan, ComplianceStatus.full
+
+    has_blocking = any(
+        v.type in (ViolationType.allergy, ViolationType.diet) for v in remaining
+    )
+    if not has_blocking:
+        # Seul le budget est viole : on conserve le plan LLM, charge au caller
+        # de logger des warnings (cf. issue #52 : "warnings explicites").
+        return plan, ComplianceStatus.partial_budget
+
+    # Fallback hierarchique : plan statique correspondant a (objectif, regime).
+    raw = load_fallback_plan(inputs.objective, inputs.diet_type or "")
+    if raw is None:
+        raise InfeasibleConstraintsError(
+            f"Pas de plan statique pour {inputs.objective} / {inputs.diet_type}, "
+            "impossible de satisfaire allergies/regime."
+        )
+    fallback = FallbackMealPlan.model_validate(raw)
+    fb_violations = validate_constraints(fallback, spec)
+    if any(
+        v.type in (ViolationType.allergy, ViolationType.diet) for v in fb_violations
+    ):
+        raise InfeasibleConstraintsError(
+            "Le plan statique de fallback viole les allergies / regime."
+        )
+    if any(v.type is ViolationType.budget for v in fb_violations):
+        return fallback, ComplianceStatus.partial_budget
+    return fallback, ComplianceStatus.static_fallback
+
+
+def _build_constraint_spec(inputs: PlanInputs) -> ConstraintSpec:
+    budget = float(inputs.budget_per_day) if inputs.budget_per_day is not None else None
+    return ConstraintSpec(
+        allergies=list(inputs.allergies),
+        max_daily_budget_eur=budget,
+        diet_type=inputs.diet_type,
+    )
+
+
+def _build_plan_prompt(inputs: PlanInputs) -> str:
+    return _PLAN_PROMPT_TEMPLATE.format(
+        duration_days=inputs.duration_days,
+        objective=inputs.objective,
+        diet_type=inputs.diet_type or "aucun",
+        allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
+        budget=f"{inputs.budget_per_day} EUR"
+        if inputs.budget_per_day
+        else "non specifie",
+        calories_target=inputs.calories_target or "non specifiee",
+    )
+
+
+def _build_meal_regen_prompt(violation: ConstraintViolation, inputs: PlanInputs) -> str:
+    return _MEAL_REGEN_PROMPT_TEMPLATE.format(
+        ingredient=str(violation.ingredient_or_amount),
+        diet_type=inputs.diet_type or "aucun",
+        allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
+    )
+
+
+def _build_day_regen_prompt(
+    plan: FallbackMealPlan,
+    violation: ConstraintViolation,
+    spec: ConstraintSpec,
+) -> str:
+    day = next(d for d in plan.days if d.day == violation.day)
+    budget_max = spec.max_daily_budget_eur or 0.0
+    day_total = float(violation.ingredient_or_amount)
+    return _DAY_REGEN_PROMPT_TEMPLATE.format(
+        overflow=day_total - budget_max,
+        budget_max=budget_max,
+        meals_count=len(day.meals),
+        diet_type=spec.diet_type or "aucun",
+    )
+
+
+async def _call_for_plan(prompt: str) -> FallbackMealPlan:
+    raw = await _ollama_generate(prompt, FallbackMealPlan.model_json_schema())
+    parsed = json.loads(raw)
+    if isinstance(parsed, dict):
+        parsed.setdefault("fallback", False)
+    return FallbackMealPlan.model_validate(parsed)
+
+
+async def _call_for_meal(prompt: str) -> Meal:
+    raw = await _ollama_generate(prompt, Meal.model_json_schema())
+    return Meal.model_validate_json(raw)
+
+
+async def _call_for_day(prompt: str) -> MealDay:
+    raw = await _ollama_generate(prompt, MealDay.model_json_schema())
+    return MealDay.model_validate_json(raw)
+
+
+async def _ollama_generate(prompt: str, schema: dict[str, Any]) -> str:
+    payload: dict[str, Any] = {
+        "model": _OLLAMA_MODEL,
+        "prompt": prompt,
+        "stream": False,
+        "format": schema,
+    }
+    async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT_S) as client:
+        resp = await client.post(f"{settings.ollama_host}/api/generate", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("response", "")
+
+
+def _replace_meal(
+    plan: FallbackMealPlan, day_num: int, meal_idx: int, new_meal: Meal
+) -> FallbackMealPlan:
+    new_days: list[MealDay] = []
+    for d in plan.days:
+        if d.day != day_num:
+            new_days.append(d)
+            continue
+        new_meals = list(d.meals)
+        new_meals[meal_idx] = new_meal
+        new_days.append(MealDay(day=d.day, meals=new_meals))
+    return FallbackMealPlan(fallback=plan.fallback, days=new_days)
+
+
+def _replace_day(
+    plan: FallbackMealPlan, day_num: int, new_day: MealDay
+) -> FallbackMealPlan:
+    # Force le numero de jour : le LLM peut renvoyer un day=1 sur un sous-prompt.
+    new_days = [
+        MealDay(day=day_num, meals=new_day.meals) if d.day == day_num else d
+        for d in plan.days
+    ]
+    return FallbackMealPlan(fallback=plan.fallback, days=new_days)

--- a/tests/unit/test_decrim_retry_orchestrator.py
+++ b/tests/unit/test_decrim_retry_orchestrator.py
@@ -218,6 +218,46 @@ async def test_three_retries_fail_on_budget_returns_partial_budget(
     assert sum(m.est_budget_eur for m in plan.days[0].meals) == 15.0
 
 
+# T6bis : 3 retries echoues sur allergie -> fallback statique propre -> static_fallback.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_then_clean_fallback_returns_static_fallback(
+    mock_ollama: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inputs = PlanInputs(
+        user_id=7,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    bad_plan = _plan_dict([[bad_meal]])
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"])
+    safe_plan = _plan_dict([[safe_meal]])
+    # 4 reponses LLM toutes allergenes : initial + 2 partiels + 1 plan complet (garde-fou).
+    bad_meal_resp = _ollama_response(bad_meal)
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+        ]
+    )
+    # Plan statique de fallback propre (pas d'arachides) -> static_fallback.
+    monkeypatch.setattr(
+        "app.services.decrim_retry_orchestrator.load_fallback_plan",
+        lambda _goal, _diet: safe_plan,
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.static_fallback
+    assert plan.days[0].meals[0].name == "Salade poulet"
+
+
 # T6 : garde-fou anti-cycle. Apres 2 retries partiels sur le meme repas,
 # basculer en retry complet du plan.
 

--- a/tests/unit/test_decrim_retry_orchestrator.py
+++ b/tests/unit/test_decrim_retry_orchestrator.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from app.models.schemas import FallbackMealPlan, PlanInputs
+from app.services.decrim_retry_orchestrator import (
+    ComplianceStatus,
+    InfeasibleConstraintsError,
+    generate_with_retry,
+)
+
+
+# Helpers : reponses Ollama deterministe pour les tests.
+
+
+def _ollama_response(payload: dict[str, Any] | str) -> dict[str, Any]:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    return {"response": body, "done": True}
+
+
+def _meal(
+    name: str = "Salade poulet",
+    ingredients: list[str] | None = None,
+    cost: float = 4.0,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "macros": {
+            "calories": 500,
+            "protein_g": 30.0,
+            "carbs_g": 40.0,
+            "fat_g": 18.0,
+        },
+        "ingredients": ingredients or ["poulet", "salade", "tomate"],
+        "est_budget_eur": cost,
+        "prep_time_min": 15,
+    }
+
+
+def _plan_dict(
+    meals_per_day: list[list[dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Plan complet conforme au schema FallbackMealPlan."""
+    if meals_per_day is None:
+        meals_per_day = [[_meal()]]
+    return {
+        "fallback": False,
+        "days": [
+            {"day": idx + 1, "meals": meals} for idx, meals in enumerate(meals_per_day)
+        ],
+    }
+
+
+# T1 : tracer bullet. Plan valide au 1er essai -> ComplianceStatus.full.
+
+
+@pytest.mark.asyncio
+async def test_success_first_try_returns_full_status(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(user_id=1, objective="balance", duration_days=1)
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_response(_plan_dict())
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert isinstance(plan, FallbackMealPlan)
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"
+
+
+# T2 : retry partiel sur allergie. Le repas violant est regenere uniquement.
+
+
+@pytest.mark.asyncio
+async def test_partial_retry_on_allergy_succeeds_at_attempt_two(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=2,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(
+        name="Pad thai", ingredients=["sauce aux arachides", "nouilles"], cost=4.0
+    )
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"], cost=4.0)
+    bad_plan = _plan_dict([[bad_meal]])
+    # 2eme reponse : regeneration ciblee de l'unique repas (forme : Meal seul).
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(safe_meal)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"
+    assert "arachides" not in " ".join(plan.days[0].meals[0].ingredients).lower()
+
+
+# T3 : retry complet du jour qui depasse le budget.
+
+
+@pytest.mark.asyncio
+async def test_full_day_retry_on_budget_succeeds_at_attempt_two(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=3,
+        objective="weight_loss",
+        duration_days=2,
+        budget_per_day=10.0,
+    )
+    # Plan initial : jour 1 dans le budget, jour 2 trop cher (3 repas a 5 EUR = 15).
+    expensive_day_meals = [_meal(name=f"Plat luxe {i}", cost=5.0) for i in range(3)]
+    cheap_day_meals = [_meal(name="Plat simple", cost=3.0)]
+    bad_plan = _plan_dict([cheap_day_meals, expensive_day_meals])
+    # Jour 2 regenere : meme nombre de repas mais sous budget (3 * 3 = 9 < 10).
+    cheaper_day = {
+        "day": 2,
+        "meals": [_meal(name=f"Plat economique {i}", cost=3.0) for i in range(3)],
+    }
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(cheaper_day)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    day_2 = next(d for d in plan.days if d.day == 2)
+    assert sum(m.est_budget_eur for m in day_2.meals) <= 10.0
+    assert all("economique" in m.name for m in day_2.meals)
+
+
+# T4 : 3 retries echoues + fallback statique allergene -> InfeasibleConstraintsError.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_then_fallback_with_allergy_raises(
+    mock_ollama: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inputs = PlanInputs(
+        user_id=4,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    bad_plan = _plan_dict([[bad_meal]])
+    # Sequence : plan initial allergene -> 2 retries partiels allergenes -> garde-fou
+    # bascule en retry plan complet (encore allergene) -> fallback statique allergene
+    # -> InfeasibleConstraintsError.
+    bad_meal_resp = _ollama_response(bad_meal)
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+        ]
+    )
+
+    # Plan statique de fallback aussi allergene -> 503.
+    monkeypatch.setattr(
+        "app.services.decrim_retry_orchestrator.load_fallback_plan",
+        lambda _goal, _diet: bad_plan,
+    )
+
+    with pytest.raises(InfeasibleConstraintsError):
+        await generate_with_retry(inputs)
+
+
+# T5 : 3 retries echoues sur le budget -> ComplianceStatus.partial_budget.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_on_budget_returns_partial_budget(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=5,
+        objective="balance",
+        duration_days=1,
+        budget_per_day=10.0,
+    )
+    expensive_meals = [_meal(name=f"Plat {i}", cost=5.0) for i in range(3)]
+    expensive_plan = _plan_dict([expensive_meals])
+    expensive_day = {"day": 1, "meals": expensive_meals}
+    # Toutes les regenerations renvoient encore au-dessus du budget : 3 * 5 = 15 > 10.
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(expensive_plan)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.partial_budget
+    # Le plan retourne reste celui issu du LLM (pas de fallback statique sur budget seul).
+    assert sum(m.est_budget_eur for m in plan.days[0].meals) == 15.0
+
+
+# T6 : garde-fou anti-cycle. Apres 2 retries partiels sur le meme repas,
+# basculer en retry complet du plan.
+
+
+@pytest.mark.asyncio
+async def test_anti_cycle_switches_to_full_plan_retry(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=6,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"])
+    bad_plan = _plan_dict([[bad_meal]])
+    safe_plan = _plan_dict([[safe_meal]])
+
+    # Ordre attendu :
+    # 1) plan initial (allergie)
+    # 2) retry partiel #1 (allergie)
+    # 3) retry partiel #2 (allergie) -> garde-fou : count=2
+    # 4) retry complet du plan (3eme retry) -> propre
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(bad_meal)),
+            httpx.Response(200, json=_ollama_response(bad_meal)),
+            httpx.Response(200, json=_ollama_response(safe_plan)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"


### PR DESCRIPTION
Closes #52

## Summary
Module `decrim_retry_orchestrator` qui encapsule la boucle DeCRIM-light : verification des contraintes via `constraint_validator`, regeneration ciblee avec feedback explicite a l'LLM, fallback hierarchique apres echecs.

Strategie hybride beta-prime :
- allergie / regime : retry partiel (regeneration du repas violant uniquement, sous-prompt cible)
- budget : retry complet du jour qui depasse
- garde-fou anti-cycle : si la meme position viole encore apres 2 retries partiels, bascule en retry complet du plan
- apres `max_retries` : fallback statique via `fallback_loader`
  - allergies/regime persistants -> `InfeasibleConstraintsError` (HTTP 503)
  - budget seul viole -> `ComplianceStatus.partial_budget`
  - sinon -> `ComplianceStatus.static_fallback`

Le module n'est pas encore branche dans `llm_client.generate_plan` : branchement reporte au Slice 7.

## Test plan
- [x] T1 succes au 1er essai -> `ComplianceStatus.full`
- [x] T2 retry partiel sur allergie reussit au 2eme essai
- [x] T3 retry complet sur budget reussit au 2eme essai
- [x] T4 abandon apres 3 echecs -> 503 (allergie persistante)
- [x] T5 abandon apres 3 echecs -> `partial_budget` (budget persistant)
- [x] T6 garde-fou anti-cycle (3eme retry partiel bascule en retry complet)
- [x] Suite complete : 233 tests passent, ruff check + format clean