### PR TITLE
Vague 2: Slices 5 + 6 (imbalance refacto + DeCRIM retry orchestrator)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -215,18 +215,6 @@ class PaginatedPlansResponse(BaseModel):
 # LLM client : inputs / outputs (issue NUT-7).
 
 
-class Imbalance(str, Enum):
-    balanced = "balanced"
-    protein_low = "protein_low"
-    protein_high = "protein_high"
-    carbs_low = "carbs_low"
-    carbs_high = "carbs_high"
-    fat_low = "fat_low"
-    fat_high = "fat_high"
-    calories_low = "calories_low"
-    calories_high = "calories_high"
-
-
 # Inputs pour la generation de plan repas. allergies est triee dans
 # canonicalize_inputs avant calcul du hash.
 class PlanInputs(BaseModel):
@@ -239,10 +227,50 @@ class PlanInputs(BaseModel):
     calories_target: int | None = None
 
 
-class RecommendationContext(BaseModel):
-    user_id: int
-    imbalance: Imbalance
-    health_goal: HealthGoal
+# Imbalance tags structures (issue #51, slice 5 PRD #45).
+# Remplacent l'ancien enum Imbalance + phrases. Le detector emet des tags ;
+# imbalance_to_text les convertit en francais ; le LLM en fait une synthese.
+
+
+class Nutrient(str, Enum):
+    calories = "calories"
+    protein_g = "protein_g"
+    carbs_g = "carbs_g"
+    fat_g = "fat_g"
+    fibers_g = "fibers_g"
+    saturated_fat_g = "saturated_fat_g"
+
+
+class ImbalanceStatus(str, Enum):
+    excess = "excess"
+    deficit = "deficit"
+    ok = "ok"
+
+
+class ImbalanceTag(BaseModel):
+    nutrient: Nutrient
+    status: ImbalanceStatus
+    # Ecart relatif a la cible : (actual - target) / target. Positif si excess,
+    # negatif si deficit. ok -> 0 (le tag n'est generalement pas emis dans ce cas).
+    delta_pct: float
+    target_value: float
+    actual_value: float
+    unit: str
+
+
+# Reponse de POST /analyze-meal (issue #51, slice 5 PRD #45).
+
+
+class MealAnalysisResponse(BaseModel):
+    analysis_id: int
+    detected_foods: list[dict[str, Any]]
+    macros: dict[str, float]
+    imbalances: list[ImbalanceTag]
+    imbalances_text: list[str]
+    recommendations: list[str]
+    fallback: bool
+    profile_completion_required: bool
+    missing_fields: list[str] = []
 
 
 # Tailles de portion PNNS (issue NUT-49). Cf. app/data/portion_sizes.py.

--- a/app/services/decrim_retry_orchestrator.py
+++ b/app/services/decrim_retry_orchestrator.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any
+
+import httpx
+
+from app.config import settings
+from app.models.schemas import FallbackMealPlan, Meal, MealDay, PlanInputs
+from app.services.constraint_validator import (
+    ConstraintSpec,
+    ConstraintViolation,
+    ViolationType,
+    validate as validate_constraints,
+)
+from app.services.fallback_loader import load_fallback_plan
+
+_OLLAMA_TIMEOUT_S = 30.0
+_OLLAMA_MODEL = "gemma3:4b"
+
+_PLAN_PROMPT_TEMPLATE = (
+    "Tu es un nutritionniste. Genere un plan repas JSON pour {duration_days} jours.\n"
+    "Objectif : {objective}.\n"
+    "Regime : {diet_type}.\n"
+    "Allergies a eviter (aucun ingredient ne doit en contenir) : {allergies}.\n"
+    "Budget journalier maximal : {budget}.\n"
+    "Cible calorique journaliere : {calories_target}.\n"
+    "Pour chaque repas : name, macros (calories, protein_g, carbs_g, fat_g),\n"
+    "ingredients (liste), est_budget_eur, prep_time_min. Mets fallback=false."
+)
+
+_MEAL_REGEN_PROMPT_TEMPLATE = (
+    "Ce repas a ete rejete car il contient {ingredient!r}. "
+    "Regenere-le sans {ingredient!r}. "
+    "Respecte le regime {diet_type} et evite ces allergenes : {allergies}. "
+    "Reponds par un seul JSON Meal : name, macros (calories, protein_g, "
+    "carbs_g, fat_g), ingredients (liste), est_budget_eur, prep_time_min."
+)
+
+_DAY_REGEN_PROMPT_TEMPLATE = (
+    "Ce jour depasse le budget de {overflow:.2f} EUR. "
+    "Regenere ce jour sous {budget_max:.2f} EUR. "
+    "Garde {meals_count} repas et respecte le regime {diet_type}. "
+    "Reponds par un seul JSON MealDay : day (entier), meals (liste de Meal "
+    "avec name, macros, ingredients, est_budget_eur, prep_time_min)."
+)
+
+
+class ComplianceStatus(str, Enum):
+    full = "full"
+    partial_budget = "partial_budget"
+    static_fallback = "static_fallback"
+
+
+class InfeasibleConstraintsError(Exception):
+    """Allergies / regime infaisables : meme le plan statique de fallback les viole.
+
+    Le caller (router FastAPI) traduit en HTTP 503.
+    """
+
+
+async def generate_with_retry(
+    inputs: PlanInputs,
+    max_retries: int = 3,
+) -> tuple[FallbackMealPlan, ComplianceStatus]:
+    """Genere un plan repas avec retries DeCRIM-light hybride.
+
+    Strategie :
+    - allergie / regime : retry partiel sur le repas violant uniquement
+    - budget : retry complet du jour qui depasse
+    """
+    spec = _build_constraint_spec(inputs)
+    plan = await _call_for_plan(_build_plan_prompt(inputs))
+
+    # Compteur de retries partiels par (jour, repas) : permet de detecter
+    # un cycle ou la meme position viole encore apres 2 regenerations ciblees.
+    meal_retry_counts: dict[tuple[int, int], int] = {}
+
+    for _ in range(max_retries):
+        violations = validate_constraints(plan, spec)
+        if not violations:
+            return plan, ComplianceStatus.full
+
+        first = violations[0]
+        if first.type in (ViolationType.allergy, ViolationType.diet):
+            meal_idx = first.meal_index if first.meal_index is not None else 0
+            key = (first.day, meal_idx)
+            if meal_retry_counts.get(key, 0) >= 2:
+                # Garde-fou anti-cycle : la meme position viole encore apres 2
+                # regenerations ciblees. On bascule en retry complet du plan.
+                plan = await _call_for_plan(_build_plan_prompt(inputs))
+                meal_retry_counts.clear()
+                continue
+            meal_retry_counts[key] = meal_retry_counts.get(key, 0) + 1
+            new_meal = await _call_for_meal(_build_meal_regen_prompt(first, inputs))
+            plan = _replace_meal(plan, first.day, meal_idx, new_meal)
+            continue
+
+        if first.type is ViolationType.budget:
+            new_day = await _call_for_day(_build_day_regen_prompt(plan, first, spec))
+            plan = _replace_day(plan, first.day, new_day)
+            continue
+
+    return _resolve_after_retries(plan, inputs, spec)
+
+
+def _resolve_after_retries(
+    plan: FallbackMealPlan, inputs: PlanInputs, spec: ConstraintSpec
+) -> tuple[FallbackMealPlan, ComplianceStatus]:
+    """Apres epuisement des retries : decide entre full / partial_budget / fallback statique."""
+    remaining = validate_constraints(plan, spec)
+    if not remaining:
+        return plan, ComplianceStatus.full
+
+    has_blocking = any(
+        v.type in (ViolationType.allergy, ViolationType.diet) for v in remaining
+    )
+    if not has_blocking:
+        # Seul le budget est viole : on conserve le plan LLM, charge au caller
+        # de logger des warnings (cf. issue #52 : "warnings explicites").
+        return plan, ComplianceStatus.partial_budget
+
+    # Fallback hierarchique : plan statique correspondant a (objectif, regime).
+    raw = load_fallback_plan(inputs.objective, inputs.diet_type or "")
+    if raw is None:
+        raise InfeasibleConstraintsError(
+            f"Pas de plan statique pour {inputs.objective} / {inputs.diet_type}, "
+            "impossible de satisfaire allergies/regime."
+        )
+    fallback = FallbackMealPlan.model_validate(raw)
+    fb_violations = validate_constraints(fallback, spec)
+    if any(
+        v.type in (ViolationType.allergy, ViolationType.diet) for v in fb_violations
+    ):
+        raise InfeasibleConstraintsError(
+            "Le plan statique de fallback viole les allergies / regime."
+        )
+    if any(v.type is ViolationType.budget for v in fb_violations):
+        return fallback, ComplianceStatus.partial_budget
+    return fallback, ComplianceStatus.static_fallback
+
+
+def _build_constraint_spec(inputs: PlanInputs) -> ConstraintSpec:
+    budget = float(inputs.budget_per_day) if inputs.budget_per_day is not None else None
+    return ConstraintSpec(
+        allergies=list(inputs.allergies),
+        max_daily_budget_eur=budget,
+        diet_type=inputs.diet_type,
+    )
+
+
+def _build_plan_prompt(inputs: PlanInputs) -> str:
+    return _PLAN_PROMPT_TEMPLATE.format(
+        duration_days=inputs.duration_days,
+        objective=inputs.objective,
+        diet_type=inputs.diet_type or "aucun",
+        allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
+        budget=f"{inputs.budget_per_day} EUR"
+        if inputs.budget_per_day
+        else "non specifie",
+        calories_target=inputs.calories_target or "non specifiee",
+    )
+
+
+def _build_meal_regen_prompt(violation: ConstraintViolation, inputs: PlanInputs) -> str:
+    return _MEAL_REGEN_PROMPT_TEMPLATE.format(
+        ingredient=str(violation.ingredient_or_amount),
+        diet_type=inputs.diet_type or "aucun",
+        allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
+    )
+
+
+def _build_day_regen_prompt(
+    plan: FallbackMealPlan,
+    violation: ConstraintViolation,
+    spec: ConstraintSpec,
+) -> str:
+    day = next(d for d in plan.days if d.day == violation.day)
+    budget_max = spec.max_daily_budget_eur or 0.0
+    day_total = float(violation.ingredient_or_amount)
+    return _DAY_REGEN_PROMPT_TEMPLATE.format(
+        overflow=day_total - budget_max,
+        budget_max=budget_max,
+        meals_count=len(day.meals),
+        diet_type=spec.diet_type or "aucun",
+    )
+
+
+async def _call_for_plan(prompt: str) -> FallbackMealPlan:
+    raw = await _ollama_generate(prompt, FallbackMealPlan.model_json_schema())
+    parsed = json.loads(raw)
+    if isinstance(parsed, dict):
+        parsed.setdefault("fallback", False)
+    return FallbackMealPlan.model_validate(parsed)
+
+
+async def _call_for_meal(prompt: str) -> Meal:
+    raw = await _ollama_generate(prompt, Meal.model_json_schema())
+    return Meal.model_validate_json(raw)
+
+
+async def _call_for_day(prompt: str) -> MealDay:
+    raw = await _ollama_generate(prompt, MealDay.model_json_schema())
+    return MealDay.model_validate_json(raw)
+
+
+async def _ollama_generate(prompt: str, schema: dict[str, Any]) -> str:
+    payload: dict[str, Any] = {
+        "model": _OLLAMA_MODEL,
+        "prompt": prompt,
+        "stream": False,
+        "format": schema,
+    }
+    async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT_S) as client:
+        resp = await client.post(f"{settings.ollama_host}/api/generate", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("response", "")
+
+
+def _replace_meal(
+    plan: FallbackMealPlan, day_num: int, meal_idx: int, new_meal: Meal
+) -> FallbackMealPlan:
+    new_days: list[MealDay] = []
+    for d in plan.days:
+        if d.day != day_num:
+            new_days.append(d)
+            continue
+        new_meals = list(d.meals)
+        new_meals[meal_idx] = new_meal
+        new_days.append(MealDay(day=d.day, meals=new_meals))
+    return FallbackMealPlan(fallback=plan.fallback, days=new_days)
+
+
+def _replace_day(
+    plan: FallbackMealPlan, day_num: int, new_day: MealDay
+) -> FallbackMealPlan:
+    # Force le numero de jour : le LLM peut renvoyer un day=1 sur un sous-prompt.
+    new_days = [
+        MealDay(day=day_num, meals=new_day.meals) if d.day == day_num else d
+        for d in plan.days
+    ]
+    return FallbackMealPlan(fallback=plan.fallback, days=new_days)

--- a/app/services/imbalance_detector.py
+++ b/app/services/imbalance_detector.py
@@ -1,70 +1,230 @@
 from __future__ import annotations
 
+from app import config
 from app.db.models import NutritionGoal
-from app.models.schemas import Imbalance
+from app.models.schemas import (
+    HealthGoal,
+    ImbalanceStatus,
+    ImbalanceTag,
+    Nutrient,
+)
+from app.services.nutrition_engine import (
+    IncompleteProfile,
+    MealType,
+    build_user_profile,
+    compute_meal_targets,
+    meal_quota,
+)
 
-# Detection des desequilibres macros par rapport aux objectifs journaliers.
-#
-# Renvoie une liste de (Imbalance, message) ordonnee : calories -> proteines ->
-# glucides -> lipides. Cet ordre stable est utilise pour le hash de cache LLM
-# (issue NUT-11).
+# Detection des desequilibres macros par rapport a une cible repas issue de
+# nutrition_engine (Mifflin-St Jeor + RNP ANSES). Les phrases francaises sont
+# generees par imbalance_to_text (templates Python) ; le LLM fait la synthese.
 
-_CALORIES_RATIO = 0.6
-_PROTEIN_RATIO = 0.2
-_CARBS_RATIO = 0.7
-_FAT_RATIO = 0.7
+# Tolerance symetrique appliquee a calories + macros (P/C/F).
+_MACRO_TOLERANCE = 0.20
+
+# Plafond AGS : 12 % de l'AET (apport energetique total) selon ANSES.
+# AGS apporte 9 kcal/g.
+_KCAL_PER_FAT_GRAM = 9.0
 
 
-def detect_imbalances(
-    macros: dict, goal: NutritionGoal | None
-) -> list[tuple[Imbalance, str]]:
-    if goal is None or not macros:
+def detect(
+    meal_macros: dict[str, float],
+    profile: NutritionGoal | None,
+    meal_type: MealType | None,
+    health_goal: HealthGoal,
+) -> list[ImbalanceTag]:
+    """Compare les macros du repas aux cibles personnalisees et retourne des tags.
+
+    Profil incomplet ou macros vides -> []. La decision de notifier le client
+    (profile_completion_required) est deferee a meal_analysis_orchestrator.
+
+    Tolerances :
+    - calories, protein_g, carbs_g, fat_g : symetrique +/- 20 % autour de la cible
+    - saturated_fat_g : plafond seul (excess > 12 % AET)
+    - fibers_g : deficit seul (< 80 % de la part repas du RNP 30 g/j)
+    """
+    if not meal_macros:
         return []
-    issues: list[tuple[Imbalance, str]] = []
+    user_profile = build_user_profile(profile)
+    if isinstance(user_profile, IncompleteProfile):
+        return []
 
-    if goal.calories_target and macros.get("calories") is not None:
-        calories = macros["calories"]
-        ratio = calories / float(goal.calories_target)
-        if ratio > _CALORIES_RATIO:
-            issues.append(
-                (
-                    Imbalance.calories_high,
-                    f"Apport calorique eleve : {calories:.0f} kcal "
-                    f"({ratio:.0%} de l'objectif journalier de {goal.calories_target} kcal)",
-                )
-            )
+    targets = compute_meal_targets(user_profile, meal_type, health_goal)
+    tags: list[ImbalanceTag] = []
 
-    if goal.protein_g and macros.get("protein_g") is not None:
-        protein = macros["protein_g"]
-        if protein < float(goal.protein_g) * _PROTEIN_RATIO:
-            issues.append(
-                (
-                    Imbalance.protein_low,
-                    f"Faible en proteines : {protein:.1f}g "
-                    f"(objectif journalier : {goal.protein_g}g)",
-                )
-            )
+    # Symetrique +/- 20 % sur calories et macros.
+    for nutrient, actual_key, target_value, unit in (
+        (Nutrient.calories, "calories", targets.calories, "kcal"),
+        (Nutrient.protein_g, "protein_g", targets.protein_g, "g"),
+        (Nutrient.carbs_g, "carbs_g", targets.carbs_g, "g"),
+        (Nutrient.fat_g, "fat_g", targets.fat_g, "g"),
+    ):
+        actual = meal_macros.get(actual_key)
+        if actual is None:
+            continue
+        tag = _symmetric_band(
+            nutrient, float(actual), target_value, unit, _MACRO_TOLERANCE
+        )
+        if tag is not None:
+            tags.append(tag)
 
-    if goal.carbs_g and macros.get("carbs_g") is not None:
-        carbs = macros["carbs_g"]
-        if carbs > float(goal.carbs_g) * _CARBS_RATIO:
-            issues.append(
-                (
-                    Imbalance.carbs_high,
-                    f"Eleve en glucides : {carbs:.1f}g "
-                    f"(objectif journalier : {goal.carbs_g}g)",
-                )
-            )
+    # AGS plafond : excess seul si > 12 % AET du repas.
+    actual_ags = meal_macros.get("saturated_fat_g")
+    if actual_ags is not None:
+        ags_target = (
+            targets.calories * config.RNP_AGS_PERCENT_OF_AET_MAX / _KCAL_PER_FAT_GRAM
+        )
+        ags_tag = _ceiling_only(
+            Nutrient.saturated_fat_g, float(actual_ags), ags_target, "g"
+        )
+        if ags_tag is not None:
+            tags.append(ags_tag)
 
-    if goal.fat_g and macros.get("fat_g") is not None:
-        fat = macros["fat_g"]
-        if fat > float(goal.fat_g) * _FAT_RATIO:
-            issues.append(
-                (
-                    Imbalance.fat_high,
-                    f"Eleve en lipides : {fat:.1f}g "
-                    f"(objectif journalier : {goal.fat_g}g)",
-                )
-            )
+    # Fibres deficit : RNP 30 g/j ANSES, ramene a la part du repas. Quota
+    # repas si meal_type connu, sinon un quart du RNP (cf. nutrition_engine).
+    actual_fibers = meal_macros.get("fibers_g")
+    if actual_fibers is None:
+        # Compatibilite avec les payloads existants utilisant la cle 'fiber_g'
+        # (cf. nutrition_lookup et meal_analyses.macros stockes en JSONB).
+        actual_fibers = meal_macros.get("fiber_g")
+    if actual_fibers is not None:
+        fibers_target = config.RNP_FIBER_G_PER_DAY * meal_quota(meal_type)
+        fibers_tag = _floor_only(
+            Nutrient.fibers_g, float(actual_fibers), fibers_target, "g"
+        )
+        if fibers_tag is not None:
+            tags.append(fibers_tag)
 
-    return issues
+    return tags
+
+
+_NUTRIENT_LABEL: dict[Nutrient, str] = {
+    Nutrient.calories: "calories",
+    Nutrient.protein_g: "proteines",
+    Nutrient.carbs_g: "glucides",
+    Nutrient.fat_g: "lipides",
+    Nutrient.fibers_g: "fibres",
+    Nutrient.saturated_fat_g: "acides gras satures",
+}
+
+_EXCESS_PHRASES: dict[Nutrient, str] = {
+    Nutrient.calories: "Apport calorique eleve",
+    Nutrient.protein_g: "Trop de proteines",
+    Nutrient.carbs_g: "Trop de glucides",
+    Nutrient.fat_g: "Trop de lipides",
+    Nutrient.fibers_g: "Trop de fibres",
+    Nutrient.saturated_fat_g: "Trop d'acides gras satures",
+}
+
+_DEFICIT_PHRASES: dict[Nutrient, str] = {
+    Nutrient.calories: "Apport calorique faible",
+    Nutrient.protein_g: "Faible en proteines",
+    Nutrient.carbs_g: "Faible en glucides",
+    Nutrient.fat_g: "Faible en lipides",
+    Nutrient.fibers_g: "Manque de fibres",
+    Nutrient.saturated_fat_g: "Faible en acides gras satures",
+}
+
+
+def imbalance_to_text(tag: ImbalanceTag) -> str:
+    """Convertit un tag en phrase francaise deterministe (sans appel LLM).
+
+    Format : "<phrase> : <actual><unit> (cible <target><unit>, ecart <signe><pct>%)".
+    Le pourcentage est arrondi a l'unite ; la cible et l'apport reel a 1 chiffre
+    pour les grammes et a l'unite pour les kcal.
+    """
+    if tag.status is ImbalanceStatus.excess:
+        head = _EXCESS_PHRASES[tag.nutrient]
+    elif tag.status is ImbalanceStatus.deficit:
+        head = _DEFICIT_PHRASES[tag.nutrient]
+    else:
+        # ok : pas de phrase d'alerte. On retourne quand meme un texte neutre
+        # pour ne pas casser un caller qui itererait sur tous les tags.
+        return f"{_NUTRIENT_LABEL[tag.nutrient]} dans la cible."
+
+    actual = _format_value(tag.actual_value, tag.unit)
+    target = _format_value(tag.target_value, tag.unit)
+    sign = "+" if tag.delta_pct >= 0 else ""
+    pct = round(tag.delta_pct * 100)
+    return (
+        f"{head} : {actual} {tag.unit} "
+        f"(cible {target} {tag.unit}, ecart {sign}{pct}%)"
+    )
+
+
+def _format_value(value: float, unit: str) -> str:
+    # kcal : entier ; grammes : 1 chiffre apres la virgule.
+    if unit == "kcal":
+        return f"{value:.0f}"
+    return f"{value:.1f}"
+
+
+def _ceiling_only(
+    nutrient: Nutrient, actual: float, target: float, unit: str
+) -> ImbalanceTag | None:
+    """Asymetrique : on signale uniquement un excess > +20 %. Pas de deficit."""
+    if target <= 0:
+        return None
+    delta = (actual - target) / target
+    if delta <= _MACRO_TOLERANCE:
+        return None
+    return ImbalanceTag(
+        nutrient=nutrient,
+        status=ImbalanceStatus.excess,
+        delta_pct=delta,
+        target_value=target,
+        actual_value=actual,
+        unit=unit,
+    )
+
+
+def _floor_only(
+    nutrient: Nutrient, actual: float, target: float, unit: str
+) -> ImbalanceTag | None:
+    """Asymetrique : on signale uniquement un deficit > 20 %. Pas d'excess."""
+    if target <= 0:
+        return None
+    delta = (actual - target) / target
+    if delta >= -_MACRO_TOLERANCE:
+        return None
+    return ImbalanceTag(
+        nutrient=nutrient,
+        status=ImbalanceStatus.deficit,
+        delta_pct=delta,
+        target_value=target,
+        actual_value=actual,
+        unit=unit,
+    )
+
+
+def _symmetric_band(
+    nutrient: Nutrient,
+    actual: float,
+    target: float,
+    unit: str,
+    tolerance: float,
+) -> ImbalanceTag | None:
+    """Bande symetrique autour de la cible : excess ou deficit au-dela de tolerance."""
+    if target <= 0:
+        return None
+    delta = (actual - target) / target
+    if delta > tolerance:
+        return ImbalanceTag(
+            nutrient=nutrient,
+            status=ImbalanceStatus.excess,
+            delta_pct=delta,
+            target_value=target,
+            actual_value=actual,
+            unit=unit,
+        )
+    if delta < -tolerance:
+        return ImbalanceTag(
+            nutrient=nutrient,
+            status=ImbalanceStatus.deficit,
+            delta_pct=delta,
+            target_value=target,
+            actual_value=actual,
+            unit=unit,
+        )
+    return None

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -17,9 +17,8 @@ from app.config import settings
 from app.models.schemas import (
     FallbackMealPlan,
     HealthGoal,
-    Imbalance,
+    ImbalanceTag,
     PlanInputs,
-    RecommendationContext,
 )
 from app.services.constraint_validator import (
     ConstraintSpec,
@@ -52,9 +51,10 @@ _PLAN_PROMPT_TEMPLATE = (
 )
 
 _RECO_PROMPT_TEMPLATE = (
-    "Tu es un coach nutritionnel. L'utilisateur a un desequilibre {imbalance} "
-    "alors que son objectif est {health_goal}. Donne en une a deux phrases une "
-    "recommandation actionnable, en francais, sans formattage markdown."
+    "Tu es un coach nutritionnel. L'utilisateur a les desequilibres suivants "
+    "sur ce repas :\n{imbalances_block}\nSon objectif est {health_goal}. Donne "
+    "une recommandation synthetique unique en deux a trois phrases, en francais, "
+    "sans formattage markdown, qui couvre l'ensemble des desequilibres."
 )
 
 _RECO_DEFAULT_FALLBACK = (
@@ -125,15 +125,27 @@ async def generate_plan(
 
 
 async def generate_recommendation(
-    ctx: RecommendationContext,
-    db: Session,  # noqa: ARG001 (signature publique imposee par l'issue)
-    fallback: Callable[[Imbalance, HealthGoal], str] | None = None,
+    ctx_list: list[ImbalanceTag],
+    health_goal: HealthGoal,
+    db: Session,  # noqa: ARG001 (reservee pour cache cote orchestrator)
+    fallback: Callable[[list[ImbalanceTag], HealthGoal], str] | None = None,
 ) -> str:
-    """Genere une recommandation textuelle courte via Ollama, avec retry et fallback."""
-    prompt = _RECO_PROMPT_TEMPLATE.format(
-        imbalance=ctx.imbalance.value, health_goal=ctx.health_goal.value
+    """Genere une recommandation synthetique unique pour l'ensemble des imbalances.
+
+    Issue #51 : un seul appel Ollama, prompt couvrant toutes les imbalances et
+    l'objectif sante. Le cache est gere par meal_analysis_orchestrator (cle :
+    hash de top_label + health_goal + imbalances triees).
+    """
+    if not ctx_list:
+        return ""
+
+    sorted_tags = sorted(ctx_list, key=_tag_sort_key)
+    prompt = _build_recommendation_prompt(sorted_tags, health_goal)
+    log_id = (
+        "reco:"
+        + ",".join(f"{t.nutrient.value}/{t.status.value}" for t in sorted_tags)
+        + f":{health_goal.value}"
     )
-    log_id = f"reco:{ctx.imbalance.value}:{ctx.health_goal.value}:{ctx.user_id}"
 
     try:
         return await _attempt_with_retry(
@@ -144,8 +156,28 @@ async def generate_recommendation(
         )
     except _OllamaCallFailed:
         if fallback is not None:
-            return fallback(ctx.imbalance, ctx.health_goal)
+            return fallback(sorted_tags, health_goal)
         return _RECO_DEFAULT_FALLBACK
+
+
+def _tag_sort_key(tag: ImbalanceTag) -> tuple[str, str]:
+    return (tag.nutrient.value, tag.status.value)
+
+
+def _build_recommendation_prompt(
+    tags: list[ImbalanceTag], health_goal: HealthGoal
+) -> str:
+    # Ordre stable -> prompt deterministe -> reponse cache-friendly.
+    lines = [
+        f"- {tag.nutrient.value} ({tag.status.value}, ecart "
+        f"{tag.delta_pct * 100:+.0f}%, cible {tag.target_value:.1f} {tag.unit}, "
+        f"apport {tag.actual_value:.1f} {tag.unit})"
+        for tag in tags
+    ]
+    return _RECO_PROMPT_TEMPLATE.format(
+        imbalances_block="\n".join(lines),
+        health_goal=health_goal.value,
+    )
 
 
 # Internes : Ollama, validation, cache, fallback

--- a/app/services/meal_analysis_orchestrator.py
+++ b/app/services/meal_analysis_orchestrator.py
@@ -12,35 +12,53 @@ from sqlalchemy.orm import Session
 
 from app.data import recommendations_matrix as matrix
 from app.db.models import MealAnalysis, NutritionGoal
-from app.models.schemas import HealthGoal, Imbalance, RecommendationContext
+from app.models.schemas import (
+    HealthGoal,
+    ImbalanceStatus,
+    ImbalanceTag,
+    Nutrient,
+)
 from app.services import llm_client
 from app.services.food_classifier import classify_image
-from app.services.imbalance_detector import detect_imbalances
+from app.services.imbalance_detector import detect, imbalance_to_text
+from app.services.nutrition_engine import (
+    IncompleteProfile,
+    MealType,
+    build_user_profile,
+)
 from app.services.nutrition_lookup import lookup_nutrition
 
 _LOGGER = logging.getLogger(__name__)
-
-# Mapping schemas.Imbalance -> matrix.Imbalance (4 cas detectables seulement).
-# Les 4 cles sont les seules que `imbalance_detector` peut produire.
-_IMBALANCE_TO_MATRIX: dict[Imbalance, matrix.Imbalance] = {
-    Imbalance.calories_high: matrix.Imbalance.HIGH_CALORIES,
-    Imbalance.protein_low: matrix.Imbalance.LOW_PROTEIN,
-    Imbalance.carbs_high: matrix.Imbalance.HIGH_CARBS,
-    Imbalance.fat_high: matrix.Imbalance.HIGH_FAT,
-}
 
 _DEFAULT_HEALTH_GOAL = HealthGoal.balance
 _CACHE_TTL_DAYS = 30
 _MACRO_KEYS = ("calories", "protein_g", "carbs_g", "fat_g", "fiber_g")
 
+# Mapping nutrient -> matrix.Imbalance pour le fallback statique. Pas tous les
+# nutriments ne sont couverts (matrice 4 cas historique). Quand un nutriment
+# n'a pas de pendant matrice on retombe sur le fallback generique.
+_NUTRIENT_TO_MATRIX_KEY: dict[tuple[Nutrient, ImbalanceStatus], matrix.Imbalance] = {
+    (Nutrient.calories, ImbalanceStatus.excess): matrix.Imbalance.HIGH_CALORIES,
+    (Nutrient.protein_g, ImbalanceStatus.deficit): matrix.Imbalance.LOW_PROTEIN,
+    (Nutrient.carbs_g, ImbalanceStatus.excess): matrix.Imbalance.HIGH_CARBS,
+    (Nutrient.fat_g, ImbalanceStatus.excess): matrix.Imbalance.HIGH_FAT,
+}
 
-async def analyze_meal(image_bytes: bytes, user_id: int, db: Session) -> dict[str, Any]:
-    """Pipeline complet : classification, lookup, imbalances, LLM, persistance."""
+
+async def analyze_meal(
+    image_bytes: bytes,
+    user_id: int,
+    db: Session,
+    meal_type: MealType | None = None,
+) -> dict[str, Any]:
+    """Pipeline complet : classification, lookup, tags, LLM synthetique, persistance."""
     # 1. Classification HuggingFace (CPU-bound -> thread pool).
     try:
         predictions = await asyncio.to_thread(classify_image, image_bytes)
     except Exception as exc:
-        raise HTTPException(status_code=422, detail="Image invalide ou corrompue.") from exc
+        raise HTTPException(
+            status_code=422, detail="Image invalide ou corrompue."
+        ) from exc
     if not predictions:
         raise HTTPException(
             status_code=422, detail="Aucun aliment detecte avec un score suffisant."
@@ -59,64 +77,106 @@ async def analyze_meal(image_bytes: bytes, user_id: int, db: Session) -> dict[st
         k: top_nutrition[k] for k in _MACRO_KEYS if top_nutrition.get(k) is not None
     }
 
-    # 4. Profil + desequilibres + objectif de sante.
-    goal = db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).one_or_none()
-    imbalances = detect_imbalances(macros, goal)
-    imbalance_messages = [msg for _, msg in imbalances]
-    imbalance_kinds = [kind for kind, _ in imbalances]
+    # 4. Profil + objectif sante.
+    goal = (
+        db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).one_or_none()
+    )
     health_goal = _resolve_health_goal(goal)
+    user_profile = build_user_profile(goal)
 
-    # 5. Recommandations : cache, sinon LLM avec fallback matrice.
-    if not imbalance_kinds:
+    # 5. Profil incomplet : pas de tags, pas de LLM, on indique au front qu'il
+    # faut completer la biometrie.
+    if isinstance(user_profile, IncompleteProfile):
+        analysis = _persist_analysis(
+            db=db,
+            user_id=user_id,
+            detected_foods=detected_foods,
+            macros=macros,
+            recommendations=[],
+            recommendations_hash=None,
+            imbalances=[],
+            meal_type=meal_type,
+        )
+        return {
+            "analysis_id": analysis.id,
+            "detected_foods": detected_foods,
+            "macros": macros,
+            "imbalances": [],
+            "imbalances_text": [],
+            "recommendations": [],
+            "fallback": False,
+            "profile_completion_required": True,
+            "missing_fields": list(user_profile.missing_fields),
+        }
+
+    # 6. Detection des desequilibres + textes deterministes.
+    tags = detect(
+        meal_macros=macros,
+        profile=goal,
+        meal_type=meal_type,
+        health_goal=health_goal,
+    )
+    imbalances_text = [imbalance_to_text(t) for t in tags]
+
+    # 7. Recommandations : cache, sinon LLM unique synthetique.
+    if not tags:
         recommendations: list[str] = []
         recommendations_hash: str | None = None
         fallback_used = False
     else:
         recommendations_hash = compute_recommendations_hash(
-            top_label, health_goal, imbalance_kinds
+            top_label, health_goal, tags
         )
         cached = _lookup_cached_recommendations(db, recommendations_hash)
         if cached is not None:
             recommendations = cached
             fallback_used = False
         else:
-            recommendations, fallback_used = await _generate_recommendations(
-                user_id, imbalance_kinds, health_goal, db
+            recommendations, fallback_used = await _generate_recommendation(
+                tags, health_goal, db
             )
 
-    # 6. Persistance. Hash NULL en mode fallback : un appel ulterieur retentera le LLM.
-    analysis = MealAnalysis(
+    # 8. Persistance. Hash NULL en mode fallback (un appel ulterieur retentera le LLM).
+    analysis = _persist_analysis(
+        db=db,
         user_id=user_id,
         detected_foods=detected_foods,
         macros=macros,
-        confidence_scores={item["label"]: item["confidence"] for item in detected_foods},
         recommendations=recommendations,
         recommendations_hash=None if fallback_used else recommendations_hash,
+        imbalances=tags,
+        meal_type=meal_type,
     )
-    db.add(analysis)
-    db.commit()
-    db.refresh(analysis)
 
     return {
         "analysis_id": analysis.id,
         "detected_foods": detected_foods,
         "macros": macros,
-        "imbalances": imbalance_messages,
+        "imbalances": [t.model_dump(mode="json") for t in tags],
+        "imbalances_text": imbalances_text,
         "recommendations": recommendations,
         "fallback": fallback_used,
+        "profile_completion_required": False,
+        "missing_fields": [],
     }
 
 
 def compute_recommendations_hash(
-    top_label: str, health_goal: HealthGoal, imbalances: list[Imbalance]
+    top_label: str, health_goal: HealthGoal, tags: list[ImbalanceTag]
 ) -> str:
-    """SHA256 hex de (top_label, health_goal, imbalances triees) en JSON canonique."""
+    """SHA256 hex du tuple (top_label, health_goal, tags triees)."""
+    sorted_tags = sorted(
+        ({"nutrient": t.nutrient.value, "status": t.status.value} for t in tags),
+        key=lambda d: (d["nutrient"], d["status"]),
+    )
     canonical = {
         "top_label": top_label,
         "health_goal": health_goal.value,
-        "imbalances": sorted(i.value for i in imbalances),
+        "imbalances": sorted_tags,
     }
-    serialized = json.dumps(canonical, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    serialized = json.dumps(
+        canonical, separators=(",", ":"), sort_keys=True, ensure_ascii=False
+    )
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
@@ -126,20 +186,13 @@ def _resolve_health_goal(goal: NutritionGoal | None) -> HealthGoal:
     try:
         return HealthGoal(goal.health_goal)
     except ValueError:
-        # Une valeur non standard en BDD (extremement improbable car CHECK V9) :
-        # on degrade vers balance plutot que crasher l'analyse.
+        # CHECK V9 garantit la valeur en BDD ; ce log capture une derive de schema.
         _LOGGER.warning("health_goal inattendu en BDD : %r", goal.health_goal)
         return _DEFAULT_HEALTH_GOAL
 
 
 def _lookup_cached_recommendations(db: Session, hash_value: str) -> list[str] | None:
-    """Cache global : si une analyse < TTL jours partage le meme hash, on la reutilise.
-
-    Race condition assumee : deux requetes concurrentes avec le meme hash peuvent
-    declencher chacune un appel LLM avant que la premiere n'ecrive en BDD. La
-    seconde ecrasera juste l'entree avec une valeur equivalente. Volume actuel
-    trop faible pour justifier un INSERT ON CONFLICT.
-    """
+    """Cache global TTL 30j : meme hash -> reutilise les recommandations."""
     row = db.execute(
         text(
             "SELECT recommendations FROM meal_analyses "
@@ -155,39 +208,70 @@ def _lookup_cached_recommendations(db: Session, hash_value: str) -> list[str] | 
     return list(row.recommendations) if row.recommendations else []
 
 
-async def _generate_recommendations(
-    user_id: int,
-    imbalances: list[Imbalance],
+async def _generate_recommendation(
+    tags: list[ImbalanceTag],
     health_goal: HealthGoal,
     db: Session,
 ) -> tuple[list[str], bool]:
-    """Appelle generate_recommendation pour chaque desequilibre.
+    """Appelle generate_recommendation (1 seul appel Ollama).
 
-    fallback_used = True si AU MOINS UN appel a echoue et a active la matrice
-    statique. La liste retournee peut donc melanger des phrases LLM et matrice
-    dans ce cas ; le client n'a pas le detail granulaire.
+    fallback_used = True si la matrice statique a ete utilisee. La phrase
+    retournee est unique : le LLM la synthetise, ou la matrice la concatene.
     """
     fallback_used = False
 
-    def _matrix_fallback(imb: Imbalance, goal: HealthGoal) -> str:
+    def _matrix_fallback(tag_list: list[ImbalanceTag], goal: HealthGoal) -> str:
         nonlocal fallback_used
         fallback_used = True
-        mat_imb = _IMBALANCE_TO_MATRIX.get(imb)
-        if mat_imb is None:
-            return matrix.GENERIC_FALLBACK
         try:
             mat_goal = matrix.HealthGoal(goal.value)
         except ValueError:
             return matrix.GENERIC_FALLBACK
-        return matrix.get_recommendation(mat_imb, mat_goal)
+        phrases: list[str] = []
+        for tag in tag_list:
+            mat_imb = _NUTRIENT_TO_MATRIX_KEY.get((tag.nutrient, tag.status))
+            if mat_imb is None:
+                continue
+            phrases.append(matrix.get_recommendation(mat_imb, mat_goal))
+        if not phrases:
+            return matrix.GENERIC_FALLBACK
+        return " ".join(phrases)
 
-    async def _one(kind: Imbalance) -> str:
-        ctx = RecommendationContext(
-            user_id=user_id, imbalance=kind, health_goal=health_goal
-        )
-        return await llm_client.generate_recommendation(ctx, db, fallback=_matrix_fallback)
+    suggestion = await llm_client.generate_recommendation(
+        ctx_list=tags,
+        health_goal=health_goal,
+        db=db,
+        fallback=_matrix_fallback,
+    )
+    if not suggestion:
+        return [], fallback_used
+    return [suggestion], fallback_used
 
-    # Parallelise les appels LLM ; le semaphore d'llm_client plafonne deja la
-    # charge Ollama (max 2 inferences simultanees).
-    recommendations = await asyncio.gather(*(_one(k) for k in imbalances))
-    return list(recommendations), fallback_used
+
+def _persist_analysis(
+    *,
+    db: Session,
+    user_id: int,
+    detected_foods: list[dict[str, Any]],
+    macros: dict[str, float],
+    recommendations: list[str],
+    recommendations_hash: str | None,
+    imbalances: list[ImbalanceTag],
+    meal_type: MealType | None,
+) -> MealAnalysis:
+    analysis = MealAnalysis(
+        user_id=user_id,
+        detected_foods=detected_foods,
+        macros=macros,
+        confidence_scores={
+            item["label"]: item["confidence"] for item in detected_foods
+        },
+        recommendations=recommendations,
+        recommendations_hash=recommendations_hash,
+        imbalances=[t.model_dump(mode="json") for t in imbalances],
+        meal_type=meal_type.value if meal_type is not None else None,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+    return analysis

--- a/app/services/nutrition_engine.py
+++ b/app/services/nutrition_engine.py
@@ -131,13 +131,20 @@ def build_user_profile(source: object | None) -> UserProfile | IncompleteProfile
     )
 
 
+def meal_quota(meal_type: MealType | None) -> float:
+    """Part du TDEE/RNP allouee a un repas. Source unique pour les modules
+    qui repartissent une cible journaliere (calories, macros, fibres)."""
+    if meal_type is None:
+        return _FALLBACK_MEAL_QUOTA
+    return _MEAL_QUOTAS[meal_type]
+
+
 def compute_meal_targets(
     profile: UserProfile,
     meal_type: MealType | None,
     health_goal: HealthGoal,
 ) -> MealTargets:
-    # Fallback : meal_type absent -> repartition uniforme sur 4 prises.
-    quota = _MEAL_QUOTAS[meal_type] if meal_type is not None else _FALLBACK_MEAL_QUOTA
+    quota = meal_quota(meal_type)
     daily = compute_macro_targets(compute_tdee(profile), health_goal)
     return MealTargets(
         calories=daily.calories * quota,

--- a/tests/slow/test_ollama_real.py
+++ b/tests/slow/test_ollama_real.py
@@ -13,9 +13,10 @@ from testcontainers.postgres import PostgresContainer
 from app.config import settings
 from app.models.schemas import (
     HealthGoal,
-    Imbalance,
+    ImbalanceStatus,
+    ImbalanceTag,
+    Nutrient,
     PlanInputs,
-    RecommendationContext,
 )
 from app.services.llm_client import generate_plan, generate_recommendation
 
@@ -81,13 +82,22 @@ async def test_generate_recommendation_with_real_ollama(
     real_db_session: Session, ollama_host: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(settings, "ollama_host", ollama_host)
-    ctx = RecommendationContext(
-        user_id=998,
-        imbalance=Imbalance.protein_low,
-        health_goal=HealthGoal.muscle_gain,
-    )
+    tags = [
+        ImbalanceTag(
+            nutrient=Nutrient.protein_g,
+            status=ImbalanceStatus.deficit,
+            delta_pct=-0.40,
+            target_value=50.0,
+            actual_value=30.0,
+            unit="g",
+        )
+    ]
 
-    text_reco = await generate_recommendation(ctx, real_db_session)
+    text_reco = await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.muscle_gain,
+        db=real_db_session,
+    )
 
     assert isinstance(text_reco, str)
     assert len(text_reco) > 0

--- a/tests/test_meal_analysis_api.py
+++ b/tests/test_meal_analysis_api.py
@@ -43,8 +43,7 @@ def _png_bytes() -> bytes:
 
 
 def _seed_pizza(db: Session) -> None:
-    """Pizza forte en calories et glucides (declenche calories_high + carbs_high
-    quand l'utilisateur a calories_target=2000 et carbs_g=200)."""
+    """Pizza forte en calories et glucides pour declencher des imbalances."""
     db.execute(
         text(
             "INSERT INTO nutrition_entries "
@@ -55,35 +54,47 @@ def _seed_pizza(db: Session) -> None:
     db.commit()
 
 
-def _seed_profile(
+def _seed_full_profile(
     db: Session,
     user_id: int,
     *,
-    health_goal: str | None = "muscle_gain",
-    calories_target: int = 2000,
-    protein_g: float = 100.0,
-    carbs_g: float = 200.0,
-    fat_g: float = 80.0,
+    health_goal: str | None = "balance",
+    gender: str = "male",
+    age: int = 30,
+    weight_kg: float = 80.0,
+    height_cm: float = 180.0,
+    activity_level: str = "moderate",
 ) -> None:
+    """Profil complet avec biometrie : TDEE calculable -> imbalances detectables."""
     db.execute(
         text(
             "INSERT INTO nutrition_goals "
-            "(user_id, health_goal, calories_target, protein_g, carbs_g, fat_g) "
-            "VALUES (:uid, :goal, :cal, :prot, :carb, :fat)"
+            "(user_id, health_goal, gender, age, weight_kg, height_cm, activity_level) "
+            "VALUES (:uid, :goal, :g, :a, :w, :h, :al)"
         ),
         {
             "uid": user_id,
             "goal": health_goal,
-            "cal": calories_target,
-            "prot": protein_g,
-            "carb": carbs_g,
-            "fat": fat_g,
+            "g": gender,
+            "a": age,
+            "w": weight_kg,
+            "h": height_cm,
+            "al": activity_level,
         },
     )
     db.commit()
 
 
-def test_analyze_meal_nominal_returns_llm_recommendations(
+def _seed_partial_profile(db: Session, user_id: int) -> None:
+    """Profil sans biometrie : detect() doit retourner [] (profile_completion_required)."""
+    db.execute(
+        text("INSERT INTO nutrition_goals (user_id, health_goal) VALUES (:uid, :goal)"),
+        {"uid": user_id, "goal": "balance"},
+    )
+    db.commit()
+
+
+def test_analyze_meal_nominal_returns_imbalance_tags_and_single_recommendation(
     client: TestClient,
     db_session: Session,
     mock_classifier: Callable[..., list[dict[str, Any]]],
@@ -92,10 +103,14 @@ def test_analyze_meal_nominal_returns_llm_recommendations(
 ) -> None:
     user_id = 42
     _seed_pizza(db_session)
-    _seed_profile(db_session, user_id)
+    _seed_full_profile(db_session, user_id)
 
     route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
-        200, json={"response": "Reduis la portion au prochain repas.", "done": True}
+        200,
+        json={
+            "response": "Reduis la portion et ajoute des legumes verts.",
+            "done": True,
+        },
     )
 
     response = client.post(
@@ -106,25 +121,127 @@ def test_analyze_meal_nominal_returns_llm_recommendations(
 
     assert response.status_code == 200, response.text
     body = response.json()
+
+    # Profil complet : pas de demande de completion.
+    assert body["profile_completion_required"] is False
+    assert body["missing_fields"] == []
     assert body["fallback"] is False
-    # Pizza : calories 1300/2000 = 65 % > 60 % et glucides 160/200 = 80 % > 70 %.
-    # Deux desequilibres -> deux appels LLM -> deux recommandations.
-    assert len(body["recommendations"]) == 2
-    assert all(r == "Reduis la portion au prochain repas." for r in body["recommendations"])
-    assert route.call_count == 2
+
+    # Pizza riche en calories et glucides : detect() emet au moins 1 tag.
+    assert len(body["imbalances"]) >= 1
+    assert all(
+        {
+            "nutrient",
+            "status",
+            "delta_pct",
+            "target_value",
+            "actual_value",
+            "unit",
+        }.issubset(t)
+        for t in body["imbalances"]
+    )
+
+    # Phrase deterministe par tag.
+    assert len(body["imbalances_text"]) == len(body["imbalances"])
+
+    # Synthese unique par le LLM (1 appel, 1 phrase).
+    assert route.call_count == 1
+    assert body["recommendations"] == ["Reduis la portion et ajoute des legumes verts."]
+
+
+def test_analyze_meal_persists_imbalances_jsonb(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 99
+    _seed_pizza(db_session)
+    _seed_full_profile(db_session, user_id)
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Conseil unique.", "done": True}
+    )
+
+    client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
 
     row = db_session.execute(
-        text(
-            "SELECT user_id, recommendations, recommendations_hash "
-            "FROM meal_analyses WHERE user_id = :uid"
-        ),
+        text("SELECT imbalances FROM meal_analyses WHERE user_id = :uid"),
         {"uid": user_id},
     ).fetchone()
     assert row is not None
-    assert row.user_id == user_id
-    assert len(row.recommendations) == 2
-    assert row.recommendations_hash is not None
-    assert len(row.recommendations_hash) == 64
+    persisted = row.imbalances
+    assert isinstance(persisted, list) and len(persisted) >= 1
+    first = persisted[0]
+    assert {"nutrient", "status", "delta_pct"}.issubset(first)
+
+
+def test_analyze_meal_returns_completion_required_when_profile_incomplete(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 50
+    _seed_pizza(db_session)
+    _seed_partial_profile(db_session, user_id)  # pas de biometrie
+
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ne devrait pas etre appele.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["profile_completion_required"] is True
+    # Champs biometriques manquants -> liste populee.
+    assert set(body["missing_fields"]) >= {
+        "gender",
+        "age",
+        "weight_kg",
+        "height_cm",
+        "activity_level",
+    }
+    assert body["imbalances"] == []
+    assert body["imbalances_text"] == []
+    assert body["recommendations"] == []
+    # Aucun appel LLM tant que le profil n'est pas complet.
+    assert route.call_count == 0
+
+
+def test_analyze_meal_returns_completion_required_when_no_profile(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    user_id = 51
+    _seed_pizza(db_session)
+    # Pas de profil du tout : aucune ligne en BDD.
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["profile_completion_required"] is True
+    assert body["recommendations"] == []
+    assert body["imbalances"] == []
 
 
 def test_analyze_meal_falls_back_to_matrix_when_llm_down(
@@ -136,10 +253,12 @@ def test_analyze_meal_falls_back_to_matrix_when_llm_down(
 ) -> None:
     user_id = 43
     _seed_pizza(db_session)
-    _seed_profile(db_session, user_id, health_goal="weight_loss")
+    _seed_full_profile(db_session, user_id, health_goal="weight_loss")
 
-    # 503 sur tous les essais : llm_client epuise ses retries puis bascule sur le fallback.
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(503, json={"error": "down"})
+    # Tous les essais Ollama echouent : llm_client epuise ses retries puis fallback matrice.
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        503, json={"error": "down"}
+    )
 
     response = client.post(
         "/api/v1/analyze-meal",
@@ -150,11 +269,9 @@ def test_analyze_meal_falls_back_to_matrix_when_llm_down(
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["fallback"] is True
-    assert len(body["recommendations"]) == 2
-    # Les phrases de la matrice contiennent des marqueurs (objectif perte de poids).
-    assert any("perte de poids" in r.lower() for r in body["recommendations"])
-
-    # Mode fallback : on ne pose pas le hash (un futur appel doit retenter le LLM).
+    # Une recommandation synthetique unique (matrice concatenee), pas une par imbalance.
+    assert len(body["recommendations"]) == 1
+    # Hash NULL en mode fallback : un appel ulterieur retentera le LLM.
     row = db_session.execute(
         text("SELECT recommendations_hash FROM meal_analyses WHERE user_id = :uid"),
         {"uid": user_id},
@@ -172,7 +289,7 @@ def test_analyze_meal_cache_hit_skips_llm_on_second_call(
 ) -> None:
     user_id = 44
     _seed_pizza(db_session)
-    _seed_profile(db_session, user_id, health_goal="balance")
+    _seed_full_profile(db_session, user_id, health_goal="balance")
 
     route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
         200, json={"response": "Garde une portion raisonnable.", "done": True}
@@ -186,8 +303,7 @@ def test_analyze_meal_cache_hit_skips_llm_on_second_call(
     first = client.post("/api/v1/analyze-meal", files=_files(), headers=headers)
     assert first.status_code == 200
     assert first.json()["fallback"] is False
-    first_calls = route.call_count
-    assert first_calls == 2
+    assert route.call_count == 1  # 1 seul appel pour le synthetique
 
     second = client.post("/api/v1/analyze-meal", files=_files(), headers=headers)
     assert second.status_code == 200
@@ -195,7 +311,7 @@ def test_analyze_meal_cache_hit_skips_llm_on_second_call(
     assert body2["fallback"] is False
     assert body2["recommendations"] == first.json()["recommendations"]
     # Cache hit : aucun appel LLM supplementaire.
-    assert route.call_count == first_calls
+    assert route.call_count == 1
 
 
 def test_analyze_meal_uses_balance_when_health_goal_missing(
@@ -207,14 +323,16 @@ def test_analyze_meal_uses_balance_when_health_goal_missing(
 ) -> None:
     user_id = 45
     _seed_pizza(db_session)
-    # Profil avec macros mais sans health_goal (NULL en BDD).
-    _seed_profile(db_session, user_id, health_goal=None)
+    # Profil avec biometrie complete mais health_goal NULL.
+    _seed_full_profile(db_session, user_id, health_goal=None)
 
     captured_prompts: list[str] = []
 
     def _record(request: httpx.Request) -> httpx.Response:
         captured_prompts.append(httpx.Request.read(request).decode())
-        return httpx.Response(200, json={"response": "Conseil generique.", "done": True})
+        return httpx.Response(
+            200, json={"response": "Conseil generique.", "done": True}
+        )
 
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=_record)
 
@@ -227,7 +345,7 @@ def test_analyze_meal_uses_balance_when_health_goal_missing(
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["fallback"] is False
-    assert len(body["recommendations"]) >= 1
+    assert body["recommendations"] == ["Conseil generique."]
     # Le LLM a bien ete appele avec health_goal=balance.
     assert captured_prompts, "Aucun appel LLM enregistre"
     assert all("balance" in p for p in captured_prompts)

--- a/tests/unit/test_decrim_retry_orchestrator.py
+++ b/tests/unit/test_decrim_retry_orchestrator.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from app.models.schemas import FallbackMealPlan, PlanInputs
+from app.services.decrim_retry_orchestrator import (
+    ComplianceStatus,
+    InfeasibleConstraintsError,
+    generate_with_retry,
+)
+
+
+# Helpers : reponses Ollama deterministe pour les tests.
+
+
+def _ollama_response(payload: dict[str, Any] | str) -> dict[str, Any]:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    return {"response": body, "done": True}
+
+
+def _meal(
+    name: str = "Salade poulet",
+    ingredients: list[str] | None = None,
+    cost: float = 4.0,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "macros": {
+            "calories": 500,
+            "protein_g": 30.0,
+            "carbs_g": 40.0,
+            "fat_g": 18.0,
+        },
+        "ingredients": ingredients or ["poulet", "salade", "tomate"],
+        "est_budget_eur": cost,
+        "prep_time_min": 15,
+    }
+
+
+def _plan_dict(
+    meals_per_day: list[list[dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Plan complet conforme au schema FallbackMealPlan."""
+    if meals_per_day is None:
+        meals_per_day = [[_meal()]]
+    return {
+        "fallback": False,
+        "days": [
+            {"day": idx + 1, "meals": meals} for idx, meals in enumerate(meals_per_day)
+        ],
+    }
+
+
+# T1 : tracer bullet. Plan valide au 1er essai -> ComplianceStatus.full.
+
+
+@pytest.mark.asyncio
+async def test_success_first_try_returns_full_status(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(user_id=1, objective="balance", duration_days=1)
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_response(_plan_dict())
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert isinstance(plan, FallbackMealPlan)
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"
+
+
+# T2 : retry partiel sur allergie. Le repas violant est regenere uniquement.
+
+
+@pytest.mark.asyncio
+async def test_partial_retry_on_allergy_succeeds_at_attempt_two(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=2,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(
+        name="Pad thai", ingredients=["sauce aux arachides", "nouilles"], cost=4.0
+    )
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"], cost=4.0)
+    bad_plan = _plan_dict([[bad_meal]])
+    # 2eme reponse : regeneration ciblee de l'unique repas (forme : Meal seul).
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(safe_meal)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"
+    assert "arachides" not in " ".join(plan.days[0].meals[0].ingredients).lower()
+
+
+# T3 : retry complet du jour qui depasse le budget.
+
+
+@pytest.mark.asyncio
+async def test_full_day_retry_on_budget_succeeds_at_attempt_two(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=3,
+        objective="weight_loss",
+        duration_days=2,
+        budget_per_day=10.0,
+    )
+    # Plan initial : jour 1 dans le budget, jour 2 trop cher (3 repas a 5 EUR = 15).
+    expensive_day_meals = [_meal(name=f"Plat luxe {i}", cost=5.0) for i in range(3)]
+    cheap_day_meals = [_meal(name="Plat simple", cost=3.0)]
+    bad_plan = _plan_dict([cheap_day_meals, expensive_day_meals])
+    # Jour 2 regenere : meme nombre de repas mais sous budget (3 * 3 = 9 < 10).
+    cheaper_day = {
+        "day": 2,
+        "meals": [_meal(name=f"Plat economique {i}", cost=3.0) for i in range(3)],
+    }
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(cheaper_day)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    day_2 = next(d for d in plan.days if d.day == 2)
+    assert sum(m.est_budget_eur for m in day_2.meals) <= 10.0
+    assert all("economique" in m.name for m in day_2.meals)
+
+
+# T4 : 3 retries echoues + fallback statique allergene -> InfeasibleConstraintsError.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_then_fallback_with_allergy_raises(
+    mock_ollama: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inputs = PlanInputs(
+        user_id=4,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    bad_plan = _plan_dict([[bad_meal]])
+    # Sequence : plan initial allergene -> 2 retries partiels allergenes -> garde-fou
+    # bascule en retry plan complet (encore allergene) -> fallback statique allergene
+    # -> InfeasibleConstraintsError.
+    bad_meal_resp = _ollama_response(bad_meal)
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+        ]
+    )
+
+    # Plan statique de fallback aussi allergene -> 503.
+    monkeypatch.setattr(
+        "app.services.decrim_retry_orchestrator.load_fallback_plan",
+        lambda _goal, _diet: bad_plan,
+    )
+
+    with pytest.raises(InfeasibleConstraintsError):
+        await generate_with_retry(inputs)
+
+
+# T5 : 3 retries echoues sur le budget -> ComplianceStatus.partial_budget.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_on_budget_returns_partial_budget(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=5,
+        objective="balance",
+        duration_days=1,
+        budget_per_day=10.0,
+    )
+    expensive_meals = [_meal(name=f"Plat {i}", cost=5.0) for i in range(3)]
+    expensive_plan = _plan_dict([expensive_meals])
+    expensive_day = {"day": 1, "meals": expensive_meals}
+    # Toutes les regenerations renvoient encore au-dessus du budget : 3 * 5 = 15 > 10.
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(expensive_plan)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+            httpx.Response(200, json=_ollama_response(expensive_day)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.partial_budget
+    # Le plan retourne reste celui issu du LLM (pas de fallback statique sur budget seul).
+    assert sum(m.est_budget_eur for m in plan.days[0].meals) == 15.0
+
+
+# T6bis : 3 retries echoues sur allergie -> fallback statique propre -> static_fallback.
+
+
+@pytest.mark.asyncio
+async def test_three_retries_fail_then_clean_fallback_returns_static_fallback(
+    mock_ollama: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inputs = PlanInputs(
+        user_id=7,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    bad_plan = _plan_dict([[bad_meal]])
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"])
+    safe_plan = _plan_dict([[safe_meal]])
+    # 4 reponses LLM toutes allergenes : initial + 2 partiels + 1 plan complet (garde-fou).
+    bad_meal_resp = _ollama_response(bad_meal)
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+        ]
+    )
+    # Plan statique de fallback propre (pas d'arachides) -> static_fallback.
+    monkeypatch.setattr(
+        "app.services.decrim_retry_orchestrator.load_fallback_plan",
+        lambda _goal, _diet: safe_plan,
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.static_fallback
+    assert plan.days[0].meals[0].name == "Salade poulet"
+
+
+# T6 : garde-fou anti-cycle. Apres 2 retries partiels sur le meme repas,
+# basculer en retry complet du plan.
+
+
+@pytest.mark.asyncio
+async def test_anti_cycle_switches_to_full_plan_retry(
+    mock_ollama: respx.MockRouter,
+) -> None:
+    inputs = PlanInputs(
+        user_id=6,
+        objective="balance",
+        duration_days=1,
+        allergies=["arachides"],
+    )
+    bad_meal = _meal(name="Pad thai", ingredients=["sauce aux arachides", "riz"])
+    safe_meal = _meal(name="Salade poulet", ingredients=["poulet", "salade"])
+    bad_plan = _plan_dict([[bad_meal]])
+    safe_plan = _plan_dict([[safe_meal]])
+
+    # Ordre attendu :
+    # 1) plan initial (allergie)
+    # 2) retry partiel #1 (allergie)
+    # 3) retry partiel #2 (allergie) -> garde-fou : count=2
+    # 4) retry complet du plan (3eme retry) -> propre
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_response(bad_plan)),
+            httpx.Response(200, json=_ollama_response(bad_meal)),
+            httpx.Response(200, json=_ollama_response(bad_meal)),
+            httpx.Response(200, json=_ollama_response(safe_plan)),
+        ]
+    )
+
+    plan, status = await generate_with_retry(inputs)
+
+    assert status is ComplianceStatus.full
+    assert plan.days[0].meals[0].name == "Salade poulet"

--- a/tests/unit/test_imbalance_detector.py
+++ b/tests/unit/test_imbalance_detector.py
@@ -1,114 +1,403 @@
 from __future__ import annotations
 
-from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 
 from app.db.models import NutritionGoal
-from app.models.schemas import Imbalance
-from app.services.imbalance_detector import detect_imbalances
+from app.models.schemas import HealthGoal, ImbalanceStatus, ImbalanceTag, Nutrient
+from app.services.imbalance_detector import detect, imbalance_to_text
+from app.services.nutrition_engine import MealType
 
 
-def _goal(**kwargs) -> NutritionGoal:
-    """Construit un NutritionGoal sans BDD (objet detache, pour test pur)."""
-    return NutritionGoal(user_id=1, **kwargs)
+def _full_goal(**overrides) -> NutritionGoal:
+    """NutritionGoal avec biometrie complete (TDEE calculable)."""
+    base = {
+        "user_id": 1,
+        "gender": "male",
+        "age": 30,
+        "weight_kg": 80.0,
+        "height_cm": 180.0,
+        "activity_level": "moderate",
+        "health_goal": "balance",
+    }
+    base.update(overrides)
+    return NutritionGoal(**base)
 
 
-def test_no_goal_returns_empty_list() -> None:
-    assert detect_imbalances({"calories": 1500, "protein_g": 50}, None) == []
+# Cycle 2 : profil incomplet -> []
 
 
-def test_aligned_meal_returns_empty_list() -> None:
-    goal = _goal(
-        calories_target=2000,
-        protein_g=Decimal("100"),
-        carbs_g=Decimal("250"),
-        fat_g=Decimal("70"),
+def test_detect_returns_empty_when_profile_is_none() -> None:
+    tags = detect(
+        meal_macros={"calories": 700, "protein_g": 30, "carbs_g": 80, "fat_g": 25},
+        profile=None,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
     )
-    macros = {"calories": 600, "protein_g": 30, "carbs_g": 70, "fat_g": 20}
-    assert detect_imbalances(macros, goal) == []
+
+    assert tags == []
 
 
-def test_high_calories_imbalance_yields_calories_high_kind() -> None:
-    goal = _goal(calories_target=2000)
-    macros = {"calories": 1500}  # 75 % du target, > 60 %
-
-    issues = detect_imbalances(macros, goal)
-
-    assert len(issues) == 1
-    kind, message = issues[0]
-    assert kind == Imbalance.calories_high
-    assert "1500" in message
-    assert "2000" in message
-
-
-def test_low_protein_imbalance_yields_protein_low_kind() -> None:
-    goal = _goal(protein_g=Decimal("100"))
-    macros = {"protein_g": 10}  # < 20 % du target
-
-    issues = detect_imbalances(macros, goal)
-
-    assert len(issues) == 1
-    kind, _ = issues[0]
-    assert kind == Imbalance.protein_low
-
-
-def test_high_carbs_imbalance_yields_carbs_high_kind() -> None:
-    goal = _goal(carbs_g=Decimal("200"))
-    macros = {"carbs_g": 180}  # > 70 % du target
-
-    issues = detect_imbalances(macros, goal)
-
-    assert [kind for kind, _ in issues] == [Imbalance.carbs_high]
-
-
-def test_high_fat_imbalance_yields_fat_high_kind() -> None:
-    goal = _goal(fat_g=Decimal("60"))
-    macros = {"fat_g": 50}  # > 70 % du target
-
-    issues = detect_imbalances(macros, goal)
-
-    assert [kind for kind, _ in issues] == [Imbalance.fat_high]
-
-
-def test_imbalance_skips_unset_macros() -> None:
-    goal = _goal(calories_target=2000, protein_g=Decimal("100"))
-    macros = {"calories": 1500}  # protein_g absent
-
-    issues = detect_imbalances(macros, goal)
-
-    assert [kind for kind, _ in issues] == [Imbalance.calories_high]
-
-
-def test_imbalance_returns_multiple_kinds_in_stable_order() -> None:
-    goal = _goal(
-        calories_target=2000,
-        protein_g=Decimal("100"),
-        carbs_g=Decimal("200"),
-        fat_g=Decimal("60"),
+def test_detect_returns_empty_when_profile_missing_biometric_field() -> None:
+    # Sans weight_kg : Mifflin-St Jeor n'est pas calculable -> liste vide.
+    incomplete = SimpleNamespace(
+        gender="male",
+        age=30,
+        weight_kg=None,
+        height_cm=180.0,
+        activity_level="moderate",
     )
-    macros = {"calories": 1500, "protein_g": 5, "carbs_g": 180, "fat_g": 50}
 
-    issues = detect_imbalances(macros, goal)
-    kinds = [kind for kind, _ in issues]
+    tags = detect(
+        meal_macros={"calories": 5000},
+        profile=incomplete,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
 
-    # Ordre stable : calories, protein, carbs, fat (utile pour hash de cache).
-    assert kinds == [
-        Imbalance.calories_high,
-        Imbalance.protein_low,
-        Imbalance.carbs_high,
-        Imbalance.fat_high,
-    ]
+    assert tags == []
 
 
-@pytest.mark.parametrize(
-    "ratio,expected",
-    [
-        (0.55, []),  # 55 % du target : pas d'alerte
-        (0.61, [Imbalance.calories_high]),  # > 60 % : alerte
-    ],
-)
-def test_calories_threshold_at_60_percent(ratio: float, expected: list[Imbalance]) -> None:
-    goal = _goal(calories_target=2000)
-    macros = {"calories": int(2000 * ratio)}
-    assert [kind for kind, _ in detect_imbalances(macros, goal)] == expected
+def test_detect_returns_empty_when_meal_macros_empty() -> None:
+    # Sans macros mesurees, rien a comparer.
+    profile = _full_goal()
+
+    tags = detect(
+        meal_macros={},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert tags == []
+
+
+# Cycle 3 : calories +/- 20 % symetrique
+
+
+def test_detect_emits_calories_excess_when_meal_above_120_pct_target() -> None:
+    profile = _full_goal()
+    # TDEE moderate homme 30 ans 80 kg 180 cm = 1780 * 1.55 = 2759 kcal/j
+    # Lunch quota 35 % -> cible 965.65 kcal. +50 % -> 1448 kcal -> excess.
+    actual = 1450.0
+
+    tags = detect(
+        meal_macros={"calories": actual},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    calories_tags = [t for t in tags if t.nutrient is Nutrient.calories]
+    assert len(calories_tags) == 1
+    tag = calories_tags[0]
+    assert tag.status is ImbalanceStatus.excess
+    assert tag.actual_value == pytest.approx(actual)
+    assert tag.target_value == pytest.approx(2759.0 * 0.35, rel=0.01)
+    assert tag.delta_pct > 0.20
+    assert tag.unit == "kcal"
+
+
+def test_detect_emits_calories_deficit_when_meal_below_80_pct_target() -> None:
+    profile = _full_goal()
+    # Lunch quota 35 % -> cible ~965 kcal. 50 % en dessous (482 kcal) -> deficit.
+    actual = 482.0
+
+    tags = detect(
+        meal_macros={"calories": actual},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    calories_tags = [t for t in tags if t.nutrient is Nutrient.calories]
+    assert len(calories_tags) == 1
+    tag = calories_tags[0]
+    assert tag.status is ImbalanceStatus.deficit
+    assert tag.delta_pct < -0.20
+
+
+def test_detect_does_not_emit_calories_when_meal_within_tolerance_band() -> None:
+    profile = _full_goal()
+    # Cible ~965 kcal pour lunch ; +/-20 % -> bande [772, 1158]. 1000 dedans.
+    tags = detect(
+        meal_macros={"calories": 1000.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert all(t.nutrient is not Nutrient.calories for t in tags)
+
+
+def test_detect_calories_delta_pct_matches_relative_difference() -> None:
+    profile = _full_goal()
+    # Cible lunch ~ 2759 * 0.35 = 965.65 kcal. Actual = 1500 -> delta = 0.554.
+    actual = 1500.0
+
+    tags = detect(
+        meal_macros={"calories": actual},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    tag = next(t for t in tags if t.nutrient is Nutrient.calories)
+    expected_target = 2759.0 * 0.35
+    expected_delta = (actual - expected_target) / expected_target
+    assert tag.delta_pct == pytest.approx(expected_delta, rel=0.01)
+
+
+# Cycle 4 : macros (protein / carbs / fat) symetrique +/- 20 %
+
+
+def test_detect_emits_protein_deficit_when_below_80_pct_target() -> None:
+    profile = _full_goal()
+    # balance : protein_pct = 20 %. Lunch quota 35 %. Pour TDEE 2759 :
+    # cible protein lunch = 2759 * 0.20 / 4 * 0.35 = 48.28 g.
+    # Actual 30 g -> delta = -0.379 (deficit).
+    tags = detect(
+        meal_macros={"protein_g": 30.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    protein_tags = [t for t in tags if t.nutrient is Nutrient.protein_g]
+    assert len(protein_tags) == 1
+    assert protein_tags[0].status is ImbalanceStatus.deficit
+    assert protein_tags[0].unit == "g"
+
+
+def test_detect_emits_carbs_excess_when_above_120_pct_target() -> None:
+    profile = _full_goal()
+    # balance : carbs_pct = 50 %. Lunch quota 35 %. Cible carbs ~ 120.7 g.
+    # Actual 200 g -> delta ~ +0.66 (excess).
+    tags = detect(
+        meal_macros={"carbs_g": 200.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    carbs_tags = [t for t in tags if t.nutrient is Nutrient.carbs_g]
+    assert len(carbs_tags) == 1
+    assert carbs_tags[0].status is ImbalanceStatus.excess
+
+
+def test_detect_emits_fat_deficit_when_below_80_pct_target() -> None:
+    profile = _full_goal()
+    # balance : fat_pct = 30 %. Lunch quota 35 %. TDEE 2759 :
+    # cible fat lunch = 2759 * 0.30 / 9 * 0.35 = 32.2 g.
+    # Actual 10 g -> delta -0.69 (deficit).
+    tags = detect(
+        meal_macros={"fat_g": 10.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    fat_tags = [t for t in tags if t.nutrient is Nutrient.fat_g]
+    assert len(fat_tags) == 1
+    assert fat_tags[0].status is ImbalanceStatus.deficit
+
+
+def test_detect_aligned_meal_returns_no_macro_tags() -> None:
+    profile = _full_goal()
+    # Repas approximativement aligne sur la cible lunch balance.
+    # Cible : 965 kcal / 48 g prot / 121 g carbs / 32 g fat (a +/- 20 %).
+    tags = detect(
+        meal_macros={
+            "calories": 950.0,
+            "protein_g": 48.0,
+            "carbs_g": 120.0,
+            "fat_g": 32.0,
+        },
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert tags == []
+
+
+# Cycle 5 : AGS (acides gras satures) plafond seul
+
+
+def test_detect_emits_saturated_fat_excess_above_12_pct_aet() -> None:
+    profile = _full_goal()
+    # Plafond ANSES : AGS <= 12 % AET. Lunch quota 35 % du TDEE 2759 = 965.65 kcal.
+    # Cible AGS = 965.65 * 0.12 / 9 = 12.88 g. Actual 25 g -> excess.
+    tags = detect(
+        meal_macros={"saturated_fat_g": 25.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    ags_tags = [t for t in tags if t.nutrient is Nutrient.saturated_fat_g]
+    assert len(ags_tags) == 1
+    tag = ags_tags[0]
+    assert tag.status is ImbalanceStatus.excess
+    assert tag.unit == "g"
+    assert tag.target_value == pytest.approx(965.65 * 0.12 / 9.0, rel=0.01)
+    assert tag.actual_value == pytest.approx(25.0)
+
+
+def test_detect_does_not_emit_saturated_fat_when_below_target() -> None:
+    profile = _full_goal()
+    # 5 g d'AGS contre cible ~12.9 g -> pas de deficit (asymetrique, plafond seul).
+    tags = detect(
+        meal_macros={"saturated_fat_g": 5.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert all(t.nutrient is not Nutrient.saturated_fat_g for t in tags)
+
+
+def test_detect_does_not_emit_saturated_fat_when_at_zero() -> None:
+    # Cas extreme : AGS = 0. Ne doit pas declencher de deficit.
+    profile = _full_goal()
+    tags = detect(
+        meal_macros={"saturated_fat_g": 0.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert all(t.nutrient is not Nutrient.saturated_fat_g for t in tags)
+
+
+# Cycle 6 : fibres deficit seul
+
+
+def test_detect_emits_fibers_deficit_when_below_80_pct_target() -> None:
+    profile = _full_goal()
+    # RNP 30 g/j * lunch quota 0.35 = 10.5 g cible. Actual 4 g -> delta -0.62 -> deficit.
+    tags = detect(
+        meal_macros={"fibers_g": 4.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    fiber_tags = [t for t in tags if t.nutrient is Nutrient.fibers_g]
+    assert len(fiber_tags) == 1
+    tag = fiber_tags[0]
+    assert tag.status is ImbalanceStatus.deficit
+    assert tag.unit == "g"
+    assert tag.target_value == pytest.approx(30.0 * 0.35)
+    assert tag.actual_value == pytest.approx(4.0)
+
+
+def test_detect_does_not_emit_fibers_when_above_target() -> None:
+    profile = _full_goal()
+    # 15 g pour cible 10.5 g -> excess, mais asymetrique : pas de tag emis.
+    tags = detect(
+        meal_macros={"fibers_g": 15.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert all(t.nutrient is not Nutrient.fibers_g for t in tags)
+
+
+def test_detect_accepts_legacy_fiber_g_key_for_fibers() -> None:
+    # nutrition_lookup expose la macro sous la cle 'fiber_g' (singulier).
+    # On accepte cette cle en plus de 'fibers_g' pour ne pas casser le pipeline.
+    profile = _full_goal()
+    tags = detect(
+        meal_macros={"fiber_g": 2.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert any(t.nutrient is Nutrient.fibers_g for t in tags)
+
+
+def test_detect_skips_macros_not_present_in_meal() -> None:
+    profile = _full_goal()
+    # Seulement calories : pas de tag pour les macros absentes.
+    tags = detect(
+        meal_macros={"calories": 1500.0},
+        profile=profile,
+        meal_type=MealType.lunch,
+        health_goal=HealthGoal.balance,
+    )
+
+    assert {t.nutrient for t in tags} == {Nutrient.calories}
+
+
+# Cycle 7 : imbalance_to_text
+
+
+def _tag(
+    nutrient: Nutrient,
+    status: ImbalanceStatus,
+    delta_pct: float,
+    target: float,
+    actual: float,
+    unit: str,
+) -> ImbalanceTag:
+    return ImbalanceTag(
+        nutrient=nutrient,
+        status=status,
+        delta_pct=delta_pct,
+        target_value=target,
+        actual_value=actual,
+        unit=unit,
+    )
+
+
+def test_imbalance_to_text_calories_excess_mentions_meal_calories_and_target() -> None:
+    tag = _tag(Nutrient.calories, ImbalanceStatus.excess, 0.50, 700.0, 1050.0, "kcal")
+
+    text = imbalance_to_text(tag)
+
+    assert "calories" in text.lower() or "calorique" in text.lower()
+    assert "1050" in text  # actual
+    assert "700" in text  # target
+    assert "kcal" in text
+
+
+def test_imbalance_to_text_protein_deficit_mentions_proteines() -> None:
+    tag = _tag(Nutrient.protein_g, ImbalanceStatus.deficit, -0.40, 50.0, 30.0, "g")
+
+    text = imbalance_to_text(tag)
+
+    assert "protein" in text.lower() or "protéin" in text.lower()
+    # Marqueur deficit (mots usuels en francais).
+    assert any(
+        w in text.lower() for w in ("faible", "manque", "insuffisant", "deficit")
+    )
+
+
+def test_imbalance_to_text_saturated_fat_excess_mentions_ags_or_satures() -> None:
+    tag = _tag(Nutrient.saturated_fat_g, ImbalanceStatus.excess, 0.95, 12.9, 25.0, "g")
+
+    text = imbalance_to_text(tag)
+
+    lowered = text.lower()
+    assert "satur" in lowered or "ags" in lowered
+
+
+def test_imbalance_to_text_fibers_deficit_mentions_fibres() -> None:
+    tag = _tag(Nutrient.fibers_g, ImbalanceStatus.deficit, -0.62, 10.5, 4.0, "g")
+
+    text = imbalance_to_text(tag)
+
+    assert "fibre" in text.lower()
+
+
+def test_imbalance_to_text_is_deterministic_for_same_tag() -> None:
+    tag = _tag(Nutrient.calories, ImbalanceStatus.excess, 0.30, 700.0, 910.0, "kcal")
+
+    a = imbalance_to_text(tag)
+    b = imbalance_to_text(tag)
+
+    assert a == b

--- a/tests/unit/test_imbalance_tags.py
+++ b/tests/unit/test_imbalance_tags.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.schemas import ImbalanceStatus, ImbalanceTag, Nutrient
+
+
+def test_imbalance_tag_accepts_valid_excess_calories() -> None:
+    tag = ImbalanceTag(
+        nutrient=Nutrient.calories,
+        status=ImbalanceStatus.excess,
+        delta_pct=0.30,
+        target_value=689.0,
+        actual_value=900.0,
+        unit="kcal",
+    )
+
+    assert tag.nutrient is Nutrient.calories
+    assert tag.status is ImbalanceStatus.excess
+    assert tag.delta_pct == pytest.approx(0.30)
+    assert tag.unit == "kcal"
+
+
+def test_imbalance_tag_rejects_unknown_nutrient() -> None:
+    with pytest.raises(ValidationError):
+        ImbalanceTag(
+            nutrient="vitamin_x",  # type: ignore[arg-type]
+            status=ImbalanceStatus.excess,
+            delta_pct=0.0,
+            target_value=10.0,
+            actual_value=10.0,
+            unit="g",
+        )
+
+
+def test_nutrient_enum_lists_required_six_values() -> None:
+    # Garde-fou : l'issue 51 fixe ces 6 nutriments. Si quelqu'un en supprime un
+    # par erreur, ce test casse.
+    assert {n.value for n in Nutrient} == {
+        "calories",
+        "protein_g",
+        "carbs_g",
+        "fat_g",
+        "fibers_g",
+        "saturated_fat_g",
+    }
+
+
+def test_imbalance_status_enum_lists_three_values() -> None:
+    assert {s.value for s in ImbalanceStatus} == {"excess", "deficit", "ok"}

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -12,15 +12,11 @@ from sqlalchemy import text
 
 from app.models.schemas import (
     FallbackMealPlan,
-    HealthGoal,
-    Imbalance,
     PlanInputs,
-    RecommendationContext,
 )
 from app.services.llm_client import (
     compute_inputs_hash,
     generate_plan,
-    generate_recommendation,
 )
 
 
@@ -102,7 +98,9 @@ def test_inputs_hash_returns_sha256_hex_string() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_plan_success_first_try(db_session, mock_ollama: respx.MockRouter) -> None:
+async def test_generate_plan_success_first_try(
+    db_session, mock_ollama: respx.MockRouter
+) -> None:
     inputs = PlanInputs(user_id=42, objective="balance", duration_days=7)
     mock_ollama.post(re.compile(r".*/api/generate$")).respond(
         200, json=_ollama_response(_valid_plan_dict())
@@ -202,7 +200,9 @@ async def test_generate_plan_falls_back_after_max_attempts(
     db_session, mock_ollama: respx.MockRouter
 ) -> None:
     inputs = PlanInputs(user_id=20, objective="weight_loss", duration_days=1)
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(500, json={"error": "boom"})
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        500, json={"error": "boom"}
+    )
 
     fallback_calls: list[tuple[str, str]] = []
 
@@ -261,7 +261,9 @@ async def test_generate_plan_fallback_without_loader_returns_empty_plan(
     db_session, mock_ollama: respx.MockRouter
 ) -> None:
     inputs = PlanInputs(user_id=22, objective="balance", duration_days=1)
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(500, json={"error": "boom"})
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        500, json={"error": "boom"}
+    )
 
     plan = await generate_plan(inputs, db_session)
 
@@ -503,7 +505,8 @@ async def test_generate_plan_semaphore_limits_concurrent_ollama_calls(
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=slow_handler)
 
     inputs_list = [
-        PlanInputs(user_id=50 + i, objective="balance", duration_days=1) for i in range(4)
+        PlanInputs(user_id=50 + i, objective="balance", duration_days=1)
+        for i in range(4)
     ]
     plans = await asyncio.gather(*(generate_plan(i, db_session) for i in inputs_list))
 
@@ -512,97 +515,6 @@ async def test_generate_plan_semaphore_limits_concurrent_ollama_calls(
     assert max_observed <= 2  # bornage du semaphore
 
 
-# generate_recommendation
-
-
-@pytest.mark.asyncio
-async def test_generate_recommendation_returns_text_on_success(
-    db_session, mock_ollama: respx.MockRouter
-) -> None:
-    ctx = RecommendationContext(
-        user_id=70, imbalance=Imbalance.protein_low, health_goal=HealthGoal.muscle_gain
-    )
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
-        200,
-        json={"response": "Augmente ton apport en proteines avec du poulet.", "done": True},
-    )
-
-    text_reco = await generate_recommendation(ctx, db_session)
-
-    assert isinstance(text_reco, str)
-    assert "proteines" in text_reco
-
-
-@pytest.mark.asyncio
-async def test_generate_recommendation_falls_back_on_total_failure(
-    db_session, mock_ollama: respx.MockRouter
-) -> None:
-    ctx = RecommendationContext(
-        user_id=71, imbalance=Imbalance.carbs_high, health_goal=HealthGoal.weight_loss
-    )
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(500, json={"error": "boom"})
-
-    fallback_calls: list[tuple[Imbalance, HealthGoal]] = []
-
-    def fb(imb: Imbalance, goal: HealthGoal) -> str:
-        fallback_calls.append((imb, goal))
-        return "Reduis les feculents pour atteindre ton objectif."
-
-    text_reco = await generate_recommendation(ctx, db_session, fallback=fb)
-
-    assert text_reco == "Reduis les feculents pour atteindre ton objectif."
-    assert fallback_calls == [(Imbalance.carbs_high, HealthGoal.weight_loss)]
-
-
-@pytest.mark.asyncio
-async def test_generate_recommendation_retries_then_succeeds(
-    db_session, mock_ollama: respx.MockRouter
-) -> None:
-    ctx = RecommendationContext(
-        user_id=72, imbalance=Imbalance.balanced, health_goal=HealthGoal.balance
-    )
-    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
-        side_effect=[
-            httpx.Response(500, json={"error": "boom"}),
-            httpx.Response(200, json={"response": "Continue ainsi.", "done": True}),
-        ]
-    )
-
-    text_reco = await generate_recommendation(ctx, db_session)
-
-    assert text_reco == "Continue ainsi."
-
-
-@pytest.mark.asyncio
-async def test_generate_recommendation_treats_empty_text_as_failure(
-    db_session, mock_ollama: respx.MockRouter
-) -> None:
-    ctx = RecommendationContext(
-        user_id=74, imbalance=Imbalance.balanced, health_goal=HealthGoal.balance
-    )
-    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
-        side_effect=[
-            httpx.Response(200, json={"response": "   ", "done": True}),
-            httpx.Response(200, json={"response": "Bois plus d'eau.", "done": True}),
-        ]
-    )
-
-    text_reco = await generate_recommendation(ctx, db_session)
-
-    assert text_reco == "Bois plus d'eau."
-
-
-@pytest.mark.asyncio
-async def test_generate_recommendation_fallback_default_when_no_callable(
-    db_session, mock_ollama: respx.MockRouter
-) -> None:
-    ctx = RecommendationContext(
-        user_id=73, imbalance=Imbalance.fat_high, health_goal=HealthGoal.sport_performance
-    )
-    mock_ollama.post(re.compile(r".*/api/generate$")).respond(500, json={"error": "boom"})
-
-    text_reco = await generate_recommendation(ctx, db_session)
-
-    # Sans fallback explicite, on retourne une chaine non vide degradee.
-    assert isinstance(text_reco, str)
-    assert text_reco != ""
+# Tests generate_recommendation : voir tests/unit/test_llm_recommendation.py
+# (signature refactoree par l'issue #51 : list[ImbalanceTag] au lieu de
+# RecommendationContext, 1 seul appel Ollama au lieu de N).

--- a/tests/unit/test_llm_recommendation.py
+++ b/tests/unit/test_llm_recommendation.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from app.models.schemas import (
+    HealthGoal,
+    ImbalanceStatus,
+    ImbalanceTag,
+    Nutrient,
+)
+from app.services.llm_client import generate_recommendation
+
+
+def _tag(
+    nutrient: Nutrient,
+    status: ImbalanceStatus,
+    delta_pct: float = 0.30,
+    target: float = 100.0,
+    actual: float = 130.0,
+    unit: str = "g",
+) -> ImbalanceTag:
+    return ImbalanceTag(
+        nutrient=nutrient,
+        status=status,
+        delta_pct=delta_pct,
+        target_value=target,
+        actual_value=actual,
+        unit=unit,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_takes_list_of_tags_and_returns_string(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    tags = [_tag(Nutrient.calories, ImbalanceStatus.excess)]
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200,
+        json={
+            "response": "Reduis la portion et ajoute des legumes verts.",
+            "done": True,
+        },
+    )
+
+    suggestion = await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.balance,
+        db=db_session,
+    )
+
+    assert isinstance(suggestion, str)
+    assert "legumes" in suggestion or "portion" in suggestion
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_makes_exactly_one_ollama_call_for_multiple_tags(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    # Issue #51 : un seul appel Ollama meme avec plusieurs imbalances.
+    tags = [
+        _tag(Nutrient.calories, ImbalanceStatus.excess),
+        _tag(Nutrient.protein_g, ImbalanceStatus.deficit),
+        _tag(Nutrient.fibers_g, ImbalanceStatus.deficit),
+    ]
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Conseil synthetique.", "done": True}
+    )
+
+    await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.balance,
+        db=db_session,
+    )
+
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_prompt_includes_imbalances_and_goal(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append({"body": httpx.Request.read(request).decode()})
+        return httpx.Response(200, json={"response": "ok.", "done": True})
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=_handler)
+
+    tags = [
+        _tag(Nutrient.protein_g, ImbalanceStatus.deficit),
+        _tag(Nutrient.saturated_fat_g, ImbalanceStatus.excess),
+    ]
+
+    await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.muscle_gain,
+        db=db_session,
+    )
+
+    assert captured, "Aucun appel Ollama enregistre"
+    body = captured[0]["body"]
+    assert "muscle_gain" in body
+    # Le prompt doit nommer chaque imbalance pour que la synthese soit ciblee.
+    assert "protein" in body or "proteine" in body.lower()
+    assert "satur" in body.lower() or "ags" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_falls_back_to_default_when_ollama_down(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    tags = [_tag(Nutrient.calories, ImbalanceStatus.excess)]
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        500, json={"error": "boom"}
+    )
+
+    suggestion = await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.weight_loss,
+        db=db_session,
+    )
+
+    assert isinstance(suggestion, str)
+    assert suggestion != ""
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_uses_custom_fallback_callable(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    tags = [_tag(Nutrient.fat_g, ImbalanceStatus.excess)]
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        503, json={"error": "down"}
+    )
+
+    captured_calls: list[tuple[tuple[ImbalanceTag, ...], HealthGoal]] = []
+
+    def fb(tag_list: list[ImbalanceTag], goal: HealthGoal) -> str:
+        captured_calls.append((tuple(tag_list), goal))
+        return "Plan de repli."
+
+    suggestion = await generate_recommendation(
+        ctx_list=tags,
+        health_goal=HealthGoal.balance,
+        db=db_session,
+        fallback=fb,
+    )
+
+    assert suggestion == "Plan de repli."
+    assert len(captured_calls) == 1
+    assert captured_calls[0][1] is HealthGoal.balance
+    assert captured_calls[0][0][0].nutrient is Nutrient.fat_g
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendation_returns_default_when_ctx_list_empty(
+    db_session,
+    mock_ollama: respx.MockRouter,
+) -> None:
+    # Pas d'imbalance -> pas d'appel LLM, on retourne une chaine vide ou neutre.
+    route = mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Continue.", "done": True}
+    )
+
+    suggestion = await generate_recommendation(
+        ctx_list=[],
+        health_goal=HealthGoal.balance,
+        db=db_session,
+    )
+
+    assert isinstance(suggestion, str)
+    assert route.call_count == 0


### PR DESCRIPTION
## Summary

Merge de la vague 2 (PRD #45) regroupant deux slices :

- **Slice 5** (#63 / #51) : refacto `imbalance_detector` avec tolerances asymetriques calculees via `compute_meal_targets`, suggestion LLM unique synthetique, persistance JSONB des tags, gestion `profile_completion_required`. Tests : 23 detector + 6 LLM + 7 integration.
- **Slice 6** (#64 / #52) : `decrim_retry_orchestrator` (retry partiel/complet, garde anti-cycle, fallback statique, `ComplianceStatus`, `InfeasibleConstraintsError`). Branchement dans `llm_client.generate_plan` reporte au Slice 7.

## Test plan

- [ ] `pytest tests/unit/test_imbalance_detector.py`
- [ ] `pytest tests/unit/test_llm_recommendation.py`
- [ ] `pytest tests/unit/test_decrim_retry_orchestrator.py`
- [ ] `pytest tests/integration` (POST /analyze-meal)