### PR TITLE
[Slice 8] Integration serving_sizes dans /analyze-meal + suggestion sur portion medium

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -271,6 +271,10 @@ class MealAnalysisResponse(BaseModel):
     fallback: bool
     profile_completion_required: bool
     missing_fields: list[str] = []
+    # Slice 8 PRD #45 : 3 portions PNNS (small/medium/large) par aliment
+    # detecte, macros recalculees au prorata des grammes.
+    serving_sizes: list[list["ServingSize"]] = []
+    warnings: list[str] = []
 
 
 # Tailles de portion PNNS (issue NUT-49). Cf. app/data/portion_sizes.py.
@@ -292,3 +296,7 @@ class ServingSize(BaseModel):
     label: ServingSizeLabel
     grams: int = Field(gt=0)
     description: str | None = None
+    # Macros recalculees pour cette portion (slice 8 PRD #45). None pour les
+    # entrees PNNS de reference (portion_sizes), populee par l'orchestrator
+    # quand l'aliment a des macros lookup en BDD.
+    macros: dict[str, float] | None = None

--- a/app/routers/meal_analysis.py
+++ b/app/routers/meal_analysis.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Query,
+    UploadFile,
+)
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.schemas import PaginatedAnalysesResponse
 from app.services import jwt_decoder, meal_analysis_history
 from app.services.meal_analysis_orchestrator import analyze_meal as orchestrate
+from app.services.nutrition_engine import MealType
 
 router = APIRouter()
 
@@ -138,6 +148,10 @@ async def analyze_meal(
     photo: UploadFile = File(
         ..., description="Photo du repas (JPEG, PNG ou WebP, 10 Mo max)."
     ),
+    meal_type: MealType | None = Form(
+        default=None,
+        description="breakfast / lunch / dinner / snack. Defaut : fallback TDEE/4.",
+    ),
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ):
@@ -153,7 +167,7 @@ async def analyze_meal(
         )
 
     user_id = _user_id_from_auth(authorization)
-    return await orchestrate(image_bytes, user_id, db)
+    return await orchestrate(image_bytes, user_id, db, meal_type=meal_type)
 
 
 @router.get(

--- a/app/services/meal_analysis_orchestrator.py
+++ b/app/services/meal_analysis_orchestrator.py
@@ -10,13 +10,14 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.data import recommendations_matrix as matrix
+from app.data import portion_sizes, recommendations_matrix as matrix
 from app.db.models import MealAnalysis, NutritionGoal
 from app.models.schemas import (
     HealthGoal,
     ImbalanceStatus,
     ImbalanceTag,
     Nutrient,
+    ServingSizeLabel,
 )
 from app.services import llm_client
 from app.services.food_classifier import classify_image
@@ -70,21 +71,27 @@ async def analyze_meal(
         for label, score in predictions
     ]
 
-    # 3. Macros du repas (aliment le plus probable).
-    top_label = predictions[0][0]
-    top_nutrition = detected_foods[0]["nutrition"] or {}
-    macros: dict[str, float] = {
-        k: top_nutrition[k] for k in _MACRO_KEYS if top_nutrition.get(k) is not None
-    }
+    # 3. Tailles de portion PNNS + macros recalculees pour chaque aliment.
+    serving_sizes_by_food = [
+        _serving_sizes_for(item["label"], item["nutrition"])
+        for item in detected_foods
+    ]
 
-    # 4. Profil + objectif sante.
+    # 4. Macros du repas : portion medium de l'aliment le plus probable.
+    # Slice 8 : la suggestion LLM est generee sur cette portion (la plus probable).
+    top_label = predictions[0][0]
+    macros = _medium_portion_macros(serving_sizes_by_food[0])
+
+    # 5. Profil + objectif sante.
     goal = (
         db.query(NutritionGoal).filter(NutritionGoal.user_id == user_id).one_or_none()
     )
     health_goal = _resolve_health_goal(goal)
     user_profile = build_user_profile(goal)
 
-    # 5. Profil incomplet : pas de tags, pas de LLM, on indique au front qu'il
+    warnings = _build_warnings(meal_type)
+
+    # 6. Profil incomplet : pas de tags, pas de LLM, on indique au front qu'il
     # faut completer la biometrie.
     if isinstance(user_profile, IncompleteProfile):
         analysis = _persist_analysis(
@@ -96,6 +103,7 @@ async def analyze_meal(
             recommendations_hash=None,
             imbalances=[],
             meal_type=meal_type,
+            serving_sizes=serving_sizes_by_food,
         )
         return {
             "analysis_id": analysis.id,
@@ -107,9 +115,11 @@ async def analyze_meal(
             "fallback": False,
             "profile_completion_required": True,
             "missing_fields": list(user_profile.missing_fields),
+            "serving_sizes": serving_sizes_by_food,
+            "warnings": warnings,
         }
 
-    # 6. Detection des desequilibres + textes deterministes.
+    # 7. Detection des desequilibres + textes deterministes.
     tags = detect(
         meal_macros=macros,
         profile=goal,
@@ -118,7 +128,7 @@ async def analyze_meal(
     )
     imbalances_text = [imbalance_to_text(t) for t in tags]
 
-    # 7. Recommandations : cache, sinon LLM unique synthetique.
+    # 8. Recommandations : cache, sinon LLM unique synthetique.
     if not tags:
         recommendations: list[str] = []
         recommendations_hash: str | None = None
@@ -136,7 +146,7 @@ async def analyze_meal(
                 tags, health_goal, db
             )
 
-    # 8. Persistance. Hash NULL en mode fallback (un appel ulterieur retentera le LLM).
+    # 9. Persistance. Hash NULL en mode fallback (un appel ulterieur retentera le LLM).
     analysis = _persist_analysis(
         db=db,
         user_id=user_id,
@@ -146,6 +156,7 @@ async def analyze_meal(
         recommendations_hash=None if fallback_used else recommendations_hash,
         imbalances=tags,
         meal_type=meal_type,
+        serving_sizes=serving_sizes_by_food,
     )
 
     return {
@@ -158,6 +169,8 @@ async def analyze_meal(
         "fallback": fallback_used,
         "profile_completion_required": False,
         "missing_fields": [],
+        "serving_sizes": serving_sizes_by_food,
+        "warnings": warnings,
     }
 
 
@@ -258,6 +271,7 @@ def _persist_analysis(
     recommendations_hash: str | None,
     imbalances: list[ImbalanceTag],
     meal_type: MealType | None,
+    serving_sizes: list[list[dict[str, Any]]],
 ) -> MealAnalysis:
     analysis = MealAnalysis(
         user_id=user_id,
@@ -269,9 +283,56 @@ def _persist_analysis(
         recommendations=recommendations,
         recommendations_hash=recommendations_hash,
         imbalances=[t.model_dump(mode="json") for t in imbalances],
+        serving_sizes=serving_sizes,
         meal_type=meal_type.value if meal_type is not None else None,
     )
     db.add(analysis)
     db.commit()
     db.refresh(analysis)
     return analysis
+
+
+_MEAL_TYPE_FALLBACK_WARNING = "meal_type non specifie, fallback TDEE/4"
+
+
+def _build_warnings(meal_type: MealType | None) -> list[str]:
+    if meal_type is None:
+        return [_MEAL_TYPE_FALLBACK_WARNING]
+    return []
+
+
+def _serving_sizes_for(
+    label: str, nutrition: dict[str, Any] | None
+) -> list[dict[str, Any]]:
+    """Resout les portions PNNS et y joint les macros recalculees au prorata."""
+    portions = portion_sizes.get_serving_sizes(label)
+    return [
+        {
+            "label": p.label.value,
+            "grams": p.grams,
+            "macros": _scale_macros(nutrition, p.grams),
+        }
+        for p in portions
+    ]
+
+
+def _scale_macros(
+    nutrition: dict[str, Any] | None, grams: int
+) -> dict[str, float]:
+    """nutrition_entries stocke les valeurs pour 100 g (convention OFF/USDA)."""
+    if not nutrition:
+        return {}
+    factor = grams / 100.0
+    return {
+        k: float(nutrition[k]) * factor
+        for k in _MACRO_KEYS
+        if nutrition.get(k) is not None
+    }
+
+
+def _medium_portion_macros(portions: list[dict[str, Any]]) -> dict[str, float]:
+    """Renvoie les macros de la portion medium ; vide si aucun macro lookup."""
+    for p in portions:
+        if p["label"] == ServingSizeLabel.medium.value:
+            return dict(p["macros"])
+    return {}

--- a/app/services/meal_analysis_orchestrator.py
+++ b/app/services/meal_analysis_orchestrator.py
@@ -310,6 +310,7 @@ def _serving_sizes_for(
         {
             "label": p.label.value,
             "grams": p.grams,
+            "description": p.description,
             "macros": _scale_macros(nutrition, p.grams),
         }
         for p in portions

--- a/tests/test_meal_analysis_api.py
+++ b/tests/test_meal_analysis_api.py
@@ -349,3 +349,202 @@ def test_analyze_meal_uses_balance_when_health_goal_missing(
     # Le LLM a bien ete appele avec health_goal=balance.
     assert captured_prompts, "Aucun appel LLM enregistre"
     assert all("balance" in p for p in captured_prompts)
+
+
+# Slice 8 (#54) : serving_sizes par aliment + meal_type optionnel + suggestion
+# LLM unique sur la portion medium.
+
+
+def _patch_classifier(
+    monkeypatch: pytest.MonkeyPatch, predictions: list[tuple[str, float]]
+) -> None:
+    """Remplace classify_image par un fake retournant predictions tel quel.
+
+    Permet de bypasser le seuil de confiance et de tester avec plusieurs aliments.
+    """
+    from app.services import food_classifier, meal_analysis_orchestrator
+
+    def fake(image_bytes: bytes, **_: Any) -> list[tuple[str, float]]:
+        return predictions
+
+    monkeypatch.setattr(food_classifier, "classify_image", fake)
+    monkeypatch.setattr(meal_analysis_orchestrator, "classify_image", fake)
+
+
+def test_analyze_meal_returns_serving_sizes_per_detected_food(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """Reponse contient serving_sizes : 1 liste de 3 portions par aliment detecte."""
+    user_id = 60
+    _seed_pizza(db_session)
+    _seed_full_profile(db_session, user_id)
+    _patch_classifier(monkeypatch, [("pizza", 0.85), ("steak", 0.55)])
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "Conseil unique.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    # Deux aliments detectes : pizza et steak.
+    serving_sizes = body["serving_sizes"]
+    assert len(serving_sizes) == 2
+    for portions in serving_sizes:
+        assert len(portions) == 3
+        assert {p["label"] for p in portions} == {"small", "medium", "large"}
+        for portion in portions:
+            assert {"label", "grams", "macros"}.issubset(portion)
+            assert isinstance(portion["macros"], dict)
+            assert portion["grams"] > 0
+
+
+def test_analyze_meal_warns_when_meal_type_missing(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """Sans meal_type, la reponse contient un warning explicit (fallback TDEE/4)."""
+    user_id = 61
+    _seed_pizza(db_session)
+    _seed_full_profile(db_session, user_id)
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ok.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "meal_type non specifie, fallback TDEE/4" in body["warnings"]
+
+
+def test_analyze_meal_no_warning_when_meal_type_specified(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """meal_type fourni : pas de warning fallback dans la reponse."""
+    user_id = 62
+    _seed_pizza(db_session)
+    _seed_full_profile(db_session, user_id)
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ok.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        data={"meal_type": "lunch"},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert all(
+        "meal_type non specifie" not in w for w in body.get("warnings", [])
+    )
+
+
+def test_analyze_meal_persists_serving_sizes_and_meal_type(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """serving_sizes (JSONB) et meal_type (TEXT) sont persistes en BDD."""
+    user_id = 63
+    _seed_pizza(db_session)
+    _seed_full_profile(db_session, user_id)
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ok.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        data={"meal_type": "dinner"},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+    assert response.status_code == 200, response.text
+
+    row = db_session.execute(
+        text(
+            "SELECT serving_sizes, meal_type FROM meal_analyses "
+            "WHERE user_id = :uid"
+        ),
+        {"uid": user_id},
+    ).fetchone()
+    assert row is not None
+    assert row.meal_type == "dinner"
+
+    persisted = row.serving_sizes
+    assert isinstance(persisted, list)
+    assert len(persisted) >= 1
+    portions = persisted[0]
+    assert len(portions) == 3
+    assert {p["label"] for p in portions} == {"small", "medium", "large"}
+    for p in portions:
+        assert {"label", "grams", "macros"}.issubset(p)
+
+
+def test_analyze_meal_macros_match_medium_portion_of_top_food(
+    client: TestClient,
+    db_session: Session,
+    mock_classifier: Callable[..., list[dict[str, Any]]],
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """Slice 8 : macros du repas = portion medium de l'aliment le plus probable.
+
+    Pizza est mappee a plats_composes (medium = 350 g). nutrition_entries stocke
+    les macros pour 100 g (convention OFF/USDA), donc le repas medium = lookup * 3.5.
+    """
+    user_id = 64
+    _seed_pizza(db_session)  # 1300 cal / 100 g
+    _seed_full_profile(db_session, user_id)
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ok.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    # serving_sizes[0] = pizza (top), trouver la portion medium.
+    pizza_portions = body["serving_sizes"][0]
+    medium = next(p for p in pizza_portions if p["label"] == "medium")
+    assert medium["grams"] == 350  # plats_composes
+    assert medium["macros"]["calories"] == pytest.approx(1300 * 3.5)
+
+    # Les macros agreges du repas correspondent exactement a la portion medium.
+    assert body["macros"]["calories"] == pytest.approx(medium["macros"]["calories"])
+    assert body["macros"]["protein_g"] == pytest.approx(medium["macros"]["protein_g"])

--- a/tests/test_meal_analysis_api.py
+++ b/tests/test_meal_analysis_api.py
@@ -548,3 +548,44 @@ def test_analyze_meal_macros_match_medium_portion_of_top_food(
     # Les macros agreges du repas correspondent exactement a la portion medium.
     assert body["macros"]["calories"] == pytest.approx(medium["macros"]["calories"])
     assert body["macros"]["protein_g"] == pytest.approx(medium["macros"]["protein_g"])
+
+
+def test_analyze_meal_unmapped_food_label_falls_back_to_single_medium_portion(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ollama: respx.MockRouter,
+    valid_jwt: Callable[..., str],
+) -> None:
+    """Label hors mapping PNNS : portion_sizes renvoie 1 seule portion medium 100 g."""
+    user_id = 65
+    db_session.execute(
+        text(
+            "INSERT INTO nutrition_entries "
+            "(food_name, calories, protein_g, carbs_g, fat_g, fiber_g, source) "
+            "VALUES ('mystery_food', 200, 10, 20, 5, 2, 'TEST')"
+        )
+    )
+    db_session.commit()
+    _seed_full_profile(db_session, user_id)
+    _patch_classifier(monkeypatch, [("mystery_food", 0.9)])
+
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json={"response": "ok.", "done": True}
+    )
+
+    response = client.post(
+        "/api/v1/analyze-meal",
+        files={"photo": ("pizza.png", _png_bytes(), "image/png")},
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=user_id)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    portions = body["serving_sizes"][0]
+    assert len(portions) == 1
+    assert portions[0]["label"] == "medium"
+    assert portions[0]["grams"] == 100
+    # Macros = lookup direct (factor 1.0) puisque la portion fallback fait 100 g.
+    assert body["macros"]["calories"] == pytest.approx(200)


### PR DESCRIPTION
Closes #54

## Summary

- Branche `portion_sizes` (Slice 4) dans `meal_analysis_orchestrator` : 3 portions PNNS (small/medium/large) par aliment detecte, macros recalculees au prorata des grammes (convention OFF/USDA per 100 g).
- Macros du repas = portion medium de l'aliment top-1. Imbalances et suggestion LLM unique (Slice 5) sont calcules sur cette base.
- Ajout du champ `meal_type` (Form, optionnel : breakfast/lunch/dinner/snack) forwarde a `nutrition_engine` pour les quotas. Si absent, warning `"meal_type non specifie, fallback TDEE/4"` dans la reponse.
- Persistance `meal_analyses.serving_sizes` (JSONB) et `meal_analyses.meal_type` (TEXT) (colonnes V11).

## Test plan

- [x] `pytest -m "not slow"` : 348 passed
- [x] `ruff check .` : clean
- [ ] Verifier la doc OpenAPI (`/docs`) expose le champ `meal_type` dans `POST /analyze-meal`
- [ ] Smoke test : POST avec et sans `meal_type` retourne `serving_sizes` et `warnings` coherents
- [ ] Verifier en BDD que `serving_sizes` JSONB et `meal_type` TEXT sont bien populates apres une analyse