### PR TITLE
[Slice 7] Branchement /generate-meal-plan + compliance_status + re-eval pipeline complet

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -168,6 +168,12 @@ class MealPlanResponse(BaseModel):
     plan_id: int
     fallback: bool
     days: list[MealDay]
+    # DeCRIM-light : sortie de la boucle retry / validation / fallback (slice 7).
+    # full           : plan LLM 100% conforme aux contraintes.
+    # partial_budget : allergies + regime OK, budget legerement depasse.
+    # static_fallback: bascule sur le plan statique (LLM infaisable ou injoignable).
+    compliance_status: Literal["full", "partial_budget", "static_fallback"] = "full"
+    compliance_warnings: list[str] = Field(default_factory=list)
 
 
 class MealPlanHistoryItem(BaseModel):

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.limiter import limiter
 from app.models.schemas import MealPlanRequest, MealPlanResponse, PaginatedPlansResponse
 from app.services import jwt_decoder, meal_plan_history, meal_plan_orchestrator
+from app.services.decrim_retry_orchestrator import InfeasibleConstraintsError
 
 # Note : pas de `from __future__ import annotations` ici. Slowapi enveloppe la
 # fonction et FastAPI doit pouvoir resoudre les types Pydantic au moment de
@@ -117,7 +119,12 @@ _PLAN_RESPONSE_EXAMPLE = {
             "description": "Payload invalide (regime inconnu, duree hors [1, 30], etc)."
         },
         429: {"description": "Rate limit depasse (10/heure ou 3/minute)."},
-        503: {"description": "Ollama injoignable et fallback statique indisponible."},
+        503: {
+            "description": (
+                "Contraintes infaisables (allergies / regime impossibles a satisfaire) "
+                "ou Ollama injoignable et fallback statique indisponible."
+            )
+        },
     },
 )
 @limiter.limit("10/hour;3/minute")
@@ -128,7 +135,24 @@ async def generate_meal_plan(
     db: Session = Depends(get_db),
 ) -> MealPlanResponse:
     user_id, token = _auth(authorization)
-    return await meal_plan_orchestrator.generate(user_id, payload, token, db)
+    try:
+        return await meal_plan_orchestrator.generate(user_id, payload, token, db)
+    except InfeasibleConstraintsError:
+        # DeCRIM-light a epuise les retries et le plan statique de fallback
+        # viole encore les allergies / regime : on signale au client que la
+        # combinaison demandee est infaisable plutot que de servir un plan
+        # potentiellement dangereux. Body JSON plat : detail + infeasible cote
+        # racine, contrat explicite pour le client.
+        return JSONResponse(
+            status_code=503,
+            content={
+                "detail": (
+                    "Contraintes infaisables, ajustez vos contraintes "
+                    "(allergies / regime)."
+                ),
+                "infeasible": True,
+            },
+        )
 
 
 _PLANS_HISTORY_DESCRIPTION = """

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -123,7 +123,18 @@ _PLAN_RESPONSE_EXAMPLE = {
             "description": (
                 "Contraintes infaisables (allergies / regime impossibles a satisfaire) "
                 "ou Ollama injoignable et fallback statique indisponible."
-            )
+            ),
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": (
+                            "Contraintes infaisables, ajustez vos contraintes "
+                            "(allergies / regime)."
+                        ),
+                        "infeasible": True,
+                    }
+                }
+            },
         },
     },
 )
@@ -133,7 +144,7 @@ async def generate_meal_plan(
     payload: MealPlanRequest = Body(..., openapi_examples=_PLAN_REQUEST_EXAMPLES),
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
-) -> MealPlanResponse:
+) -> MealPlanResponse | JSONResponse:
     user_id, token = _auth(authorization)
     try:
         return await meal_plan_orchestrator.generate(user_id, payload, token, db)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -20,10 +20,10 @@ from app.models.schemas import (
     ImbalanceTag,
     PlanInputs,
 )
-from app.services.constraint_validator import (
-    ConstraintSpec,
-    ViolationType,
-    validate as validate_constraints,
+from app.services.decrim_retry_orchestrator import (
+    ComplianceStatus,
+    InfeasibleConstraintsError,
+    generate_with_retry,
 )
 
 T = TypeVar("T")
@@ -35,20 +35,9 @@ _LOGGER = logging.getLogger(__name__)
 _OLLAMA_SEMAPHORE = asyncio.Semaphore(2)
 
 _OLLAMA_TIMEOUT_S = 30.0
-_MAX_ATTEMPTS = 3  # 1 essai initial + 2 retries
+_MAX_ATTEMPTS = 3  # 1 essai initial + 2 retries (flakiness Ollama)
 _RETRY_BACKOFF_S = 0.5  # backoff exponentiel : 0.5s, 1.0s entre retries
 _OLLAMA_MODEL = "gemma3:4b"
-
-_PLAN_PROMPT_TEMPLATE = (
-    "Tu es un nutritionniste. Genere un plan repas JSON pour {duration_days} jours.\n"
-    "Objectif : {objective}.\n"
-    "Regime : {diet_type}.\n"
-    "Allergies a eviter (aucun ingredient ne doit en contenir) : {allergies}.\n"
-    "Cible calorique journaliere : {calories_target}.\n"
-    "Pour chaque repas : name, macros (calories, protein_g, carbs_g, fat_g),\n"
-    "ingredients (liste), est_budget_eur, prep_time_min. Mets fallback=false.\n"
-    "Reponds uniquement par un JSON conforme au schema fourni."
-)
 
 _RECO_PROMPT_TEMPLATE = (
     "Tu es un coach nutritionnel. L'utilisateur a les desequilibres suivants "
@@ -98,8 +87,22 @@ async def generate_plan(
     db: Session,
     bypass_cache: bool = False,
     fallback_loader: Callable[[str, str], dict[str, Any] | None] | None = None,
-) -> FallbackMealPlan:
-    """Genere un plan repas via Ollama, avec cache, retry, semaphore, validation."""
+) -> tuple[FallbackMealPlan, ComplianceStatus, list[str]]:
+    """Genere un plan repas en deleguant la boucle DeCRIM-light a l'orchestrator.
+
+    Slice 7 PRD #45 : llm_client wrappe generate_with_retry pour gerer le cache,
+    la flakiness Ollama (httpx erreurs / JSON invalide / Pydantic), la persistance
+    et le fallback applicatif. La boucle de retry sur contraintes (allergie /
+    regime / budget) vit dans decrim_retry_orchestrator.
+
+    Retours :
+      - (plan, status, warnings) tuple
+      - InfeasibleConstraintsError remontee tel quel : le router traduit en 503
+
+    Comportement flakiness : 3 tentatives orchestrateur. Chaque tentative qui
+    leve httpx/JSON/Pydantic compte pour 1. Apres _MAX_ATTEMPTS echecs ou si la
+    1ere tentative reussit avec status non-full, on s'arrete.
+    """
     inputs_hash = compute_inputs_hash(inputs)
 
     if not bypass_cache:
@@ -107,18 +110,35 @@ async def generate_plan(
         if cached is not None:
             return cached
 
-    try:
-        plan = await _attempt_with_retry(
-            prompt=_build_plan_prompt(inputs),
-            json_schema=FallbackMealPlan.model_json_schema(),
-            parse=lambda raw: _validate_plan(raw, inputs),
-            log_id=inputs_hash,
-        )
-    except _OllamaCallFailed:
-        return _build_fallback_plan(inputs, inputs_hash, db, fallback_loader)
+    last_error: Exception | None = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        start = time.monotonic()
+        try:
+            async with _OLLAMA_SEMAPHORE:
+                plan, status = await generate_with_retry(inputs)
+        except InfeasibleConstraintsError:
+            raise
+        except (httpx.HTTPError, json.JSONDecodeError, ValidationError) as exc:
+            last_error = exc
+            log_status = "retry" if attempt < _MAX_ATTEMPTS else "fallback"
+            _log_call(inputs_hash, start, attempt, log_status, error=str(exc))
+            if attempt < _MAX_ATTEMPTS:
+                # Backoff exponentiel : 0.5s, 1.0s. Laisse Ollama respirer.
+                await asyncio.sleep(_RETRY_BACKOFF_S * (2 ** (attempt - 1)))
+            continue
 
-    _persist_plan(db, plan, inputs_hash, inputs)
-    return plan
+        warnings = _build_compliance_warnings(plan, status, inputs)
+        _persist_plan(db, plan, inputs_hash, inputs, status.value, warnings)
+        _log_call(inputs_hash, start, attempt, "success")
+        return plan, status, warnings
+
+    _LOGGER.warning(
+        "llm_client : echec apres %d tentatives (log_id=%s) : %s",
+        _MAX_ATTEMPTS,
+        inputs_hash,
+        last_error,
+    )
+    return _build_fallback_plan(inputs, inputs_hash, db, fallback_loader)
 
 
 # Generation de recommandation textuelle
@@ -197,7 +217,11 @@ async def _attempt_with_retry(
     parse: Callable[[str], T],
     log_id: str,
 ) -> T:
-    """Boucle retry + semaphore commune a generate_plan / generate_recommendation."""
+    """Boucle retry + semaphore pour generate_recommendation.
+
+    generate_plan delegue desormais a decrim_retry_orchestrator et n'utilise
+    plus cette helper. Conservee pour les recommandations textuelles libres.
+    """
     last_error: Exception | None = None
     for attempt in range(1, _MAX_ATTEMPTS + 1):
         start = time.monotonic()
@@ -249,49 +273,50 @@ async def _call_ollama_generate(prompt: str, json_schema: dict[str, Any] | None)
     return data.get("response", "")
 
 
-def _validate_plan(raw_response: str, inputs: PlanInputs) -> FallbackMealPlan:
-    """Parse le JSON, valide via Pydantic, applique les regles metier."""
-    try:
-        parsed = json.loads(raw_response)
-    except json.JSONDecodeError as exc:
-        raise _PlanValidationError(f"JSON invalide : {exc}") from exc
-    # Le LLM oublie parfois 'fallback' qui est requis par le schema. On le
-    # force a False sur le chemin success ; _build_fallback_plan le met a True.
-    if isinstance(parsed, dict):
-        parsed.setdefault("fallback", False)
-    plan = FallbackMealPlan.model_validate(parsed)
-    if inputs.allergies:
-        spec = ConstraintSpec(allergies=inputs.allergies)
-        for v in validate_constraints(plan, spec):
-            if v.type is ViolationType.allergy:
-                raise _PlanValidationError(v.message)
-    return plan
+def _build_compliance_warnings(
+    plan: FallbackMealPlan,
+    status: ComplianceStatus,
+    inputs: PlanInputs,
+) -> list[str]:
+    """Genere les warnings explicites associes au compliance_status.
 
-
-def _build_plan_prompt(inputs: PlanInputs) -> str:
-    return _PLAN_PROMPT_TEMPLATE.format(
-        duration_days=inputs.duration_days,
-        objective=inputs.objective,
-        diet_type=inputs.diet_type or "aucun",
-        allergies=", ".join(sorted(inputs.allergies)) if inputs.allergies else "aucune",
-        calories_target=inputs.calories_target
-        if inputs.calories_target
-        else "non specifiee",
-    )
+    full           : aucune contrainte relachee.
+    partial_budget : enumere les jours qui depassent le budget journalier.
+    static_fallback: explique que le plan statique sert de repli.
+    """
+    if status is ComplianceStatus.full:
+        return []
+    if status is ComplianceStatus.static_fallback:
+        return ["Contraintes infaisables par le LLM, plan statique de repli."]
+    if status is ComplianceStatus.partial_budget:
+        budget = float(inputs.budget_per_day) if inputs.budget_per_day else None
+        if budget is None:
+            return ["Plan partiellement conforme (budget)."]
+        warnings: list[str] = []
+        for day in plan.days:
+            day_total = sum(meal.est_budget_eur for meal in day.meals)
+            if day_total > budget:
+                overflow = day_total - budget
+                warnings.append(
+                    f"Budget journalier depasse de {overflow:.2f} EUR le jour {day.day}."
+                )
+        return warnings or ["Plan partiellement conforme (budget)."]
+    return []
 
 
 def _lookup_cached_plan(
     db: Session, user_id: int, inputs_hash: str
-) -> FallbackMealPlan | None:
+) -> tuple[FallbackMealPlan, ComplianceStatus, list[str]] | None:
     """Recupere le dernier plan en cache (< 7 jours) pour ce inputs_hash.
 
+    Renvoie aussi compliance_status et compliance_warnings tels que persistes.
     Filtre redondant sur user_id : le hash inclut deja user_id, mais l'expliciter
     documente la requete et protege en defense-en-profondeur si la canonicalisation
     venait a changer.
     """
     row = db.execute(
         text(
-            "SELECT plan FROM meal_plans "
+            "SELECT plan, compliance_status, compliance_warnings FROM meal_plans "
             "WHERE user_id = :uid "
             "AND inputs_hash = :h "
             "AND generated_at > NOW() - INTERVAL '7 days' "
@@ -302,21 +327,31 @@ def _lookup_cached_plan(
     ).fetchone()
     if row is None:
         return None
-    return FallbackMealPlan.model_validate(row.plan)
+    plan = FallbackMealPlan.model_validate(row.plan)
+    status = ComplianceStatus(row.compliance_status or "full")
+    warnings = list(row.compliance_warnings or [])
+    return plan, status, warnings
 
 
 def _persist_plan(
-    db: Session, plan: FallbackMealPlan, inputs_hash: str, inputs: PlanInputs
+    db: Session,
+    plan: FallbackMealPlan,
+    inputs_hash: str,
+    inputs: PlanInputs,
+    compliance_status: str,
+    compliance_warnings: list[str],
 ) -> None:
-    """Insere une ligne meal_plans avec le plan complet et son inputs_hash.
+    """Insere une ligne meal_plans avec le plan complet, son inputs_hash et le compliance.
 
     Flush sans commit : la decision de commit revient au caller (handler FastAPI),
     pour ne pas finaliser une transaction qui contient peut-etre d'autres ecritures.
     """
     db.execute(
         text(
-            "INSERT INTO meal_plans (user_id, plan, objective, constraints, inputs_hash) "
-            "VALUES (:uid, CAST(:plan AS JSONB), :obj, CAST(:cons AS JSONB), :h)"
+            "INSERT INTO meal_plans (user_id, plan, objective, constraints, "
+            "inputs_hash, compliance_status, compliance_warnings) "
+            "VALUES (:uid, CAST(:plan AS JSONB), :obj, CAST(:cons AS JSONB), :h, "
+            ":status, :warnings)"
         ),
         {
             "uid": inputs.user_id,
@@ -324,6 +359,8 @@ def _persist_plan(
             "obj": inputs.objective,
             "cons": json.dumps(canonicalize_inputs(inputs)),
             "h": inputs_hash,
+            "status": compliance_status,
+            "warnings": list(compliance_warnings or []),
         },
     )
     db.flush()
@@ -334,8 +371,12 @@ def _build_fallback_plan(
     inputs_hash: str,
     db: Session,
     fallback_loader: Callable[[str, str], dict[str, Any] | None] | None,
-) -> FallbackMealPlan:
-    """Construit un plan en mode degrade : matrice statique ou squelette vide."""
+) -> tuple[FallbackMealPlan, ComplianceStatus, list[str]]:
+    """Construit un plan en mode degrade : matrice statique ou squelette vide.
+
+    Cas Ollama injoignable apres tous les retries flakiness. Le plan retourne
+    porte status=static_fallback et un warning explicitant la cause.
+    """
     raw: dict[str, Any] | None = None
     if fallback_loader is not None:
         raw = fallback_loader(inputs.objective, inputs.diet_type or "")
@@ -345,8 +386,16 @@ def _build_fallback_plan(
     raw["fallback"] = True
 
     plan = FallbackMealPlan.model_validate(raw)
-    _persist_plan(db, plan, inputs_hash, inputs)
-    return plan
+    warnings = ["Ollama injoignable, plan statique de repli."]
+    _persist_plan(
+        db,
+        plan,
+        inputs_hash,
+        inputs,
+        ComplianceStatus.static_fallback.value,
+        warnings,
+    )
+    return plan, ComplianceStatus.static_fallback, warnings
 
 
 # Logging structure

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -117,6 +117,9 @@ async def generate_plan(
             async with _OLLAMA_SEMAPHORE:
                 plan, status = await generate_with_retry(inputs)
         except InfeasibleConstraintsError:
+            # On trace l'attempt avant de remonter pour que les ops puissent
+            # correler la latence et l'inputs_hash avec le 503 cote router.
+            _log_call(inputs_hash, start, attempt, "infeasible")
             raise
         except (httpx.HTTPError, json.JSONDecodeError, ValidationError) as exc:
             last_error = exc

--- a/app/services/meal_plan_orchestrator.py
+++ b/app/services/meal_plan_orchestrator.py
@@ -30,7 +30,8 @@ async def generate(
 
     - Resout health_goal : explicite > profil > balance.
     - Bypass cache si tier in {premium, premium_plus} (issue NUT-5).
-    - Delegue cache + retry + fallback + persistance a llm_client.
+    - Delegue cache + retry + DeCRIM-light + persistance a llm_client.
+    - InfeasibleConstraintsError remontee : le router traduit en HTTP 503.
     """
     health_goal = _resolve_health_goal(request.health_goal, user_id, db)
 
@@ -39,7 +40,7 @@ async def generate(
 
     plan_inputs = _build_inputs(user_id, request, health_goal)
 
-    plan = await generate_plan(
+    plan, compliance_status, compliance_warnings = await generate_plan(
         plan_inputs,
         db,
         bypass_cache=bypass_cache,
@@ -49,7 +50,13 @@ async def generate(
     plan_id = _latest_plan_id(db, user_id, compute_inputs_hash(plan_inputs))
     db.commit()
 
-    return MealPlanResponse(plan_id=plan_id, fallback=plan.fallback, days=plan.days)
+    return MealPlanResponse(
+        plan_id=plan_id,
+        fallback=plan.fallback,
+        days=plan.days,
+        compliance_status=compliance_status.value,
+        compliance_warnings=compliance_warnings,
+    )
 
 
 def _resolve_health_goal(

--- a/docs/metrics.json
+++ b/docs/metrics.json
@@ -932,22 +932,44 @@
   },
   "generated_at": 1777534688,
   "llm": {
-    "constraint_n_plans": 10,
-    "constraint_satisfaction_rate": 0.0,
-    "fallback_rate": 0.0,
-    "hitl": {
-      "mean_coherence": 0.0,
-      "mean_nutrition": 0.0,
-      "mean_originalite": 0.0,
-      "n_ratings": 0
+    "naive": {
+      "_note": "LLM nu (gemma3:4b sans DeCRIM-light). Numeros repris de l'eval pre-slice-7.",
+      "by_constraint": {
+        "allergies": 0.0,
+        "budget": 0.0,
+        "diet": 0.0
+      },
+      "constraint_n_plans": 10,
+      "constraint_satisfaction": 0.0,
+      "fallback_rate": 0.0,
+      "hitl": {
+        "mean_coherence": 0.0,
+        "mean_nutrition": 0.0,
+        "mean_originalite": 0.0,
+        "n_ratings": 0
+      },
+      "json_validity_rate": 1.0,
+      "latency_distribution_png": "docs/llm_latency_distribution.png",
+      "latency_max_ms": 97856.14665799994,
+      "latency_p50_ms": 83654.46811300013,
+      "latency_p95_ms": 95209.65956199996,
+      "n_generations": 30
     },
-    "json_validity_rate": 1.0,
-    "latency": {
-      "max_ms": 97856.14665799994,
-      "p50_ms": 83654.46811300013,
-      "p95_ms": 95209.65956199996
-    },
-    "latency_distribution_png": "docs/llm_latency_distribution.png",
-    "n_generations": 30
+    "pipeline": {
+      "_note": "Structure cible (slice 7). Lancer `python scripts/eval_metrics.py llm` avec Ollama + PG accessibles pour peupler avec des mesures reelles.",
+      "abandoned_503": 0.0,
+      "by_constraint": {
+        "allergies": 0.0,
+        "budget": 0.0,
+        "diet": 0.0
+      },
+      "constraint_satisfaction": 0.0,
+      "latency_p50_ms": 0.0,
+      "latency_p95_ms": 0.0,
+      "n_generations": 0,
+      "partial_compliance": 0.0,
+      "retry_count_distribution": {},
+      "static_fallback": 0.0
+    }
   }
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -95,12 +95,19 @@ Top classes (precision / rappel / F1 / support) :
 
 ## LLM (Ollama gemma3:4b)
 
+Slice 7 PRD #45 : on mesure deux niveaux sur les memes inputs aleatoires
+(meme seed) pour quantifier l'apport du retry DeCRIM-light hybride.
+
+### Niveau naive (LLM nu, sans DeCRIM-light)
+
+- N generations : 30
 - Taux de validite JSON (1er essai) : 1.0000
 - Taux d'invocation Fallback : 0.0000
 - Latence : p50 83654 ms, p95 95210 ms, max 97856 ms
 - Respect simultanee allergies + budget + regime : 0.0000
+- Par contrainte : allergies 0.0000, budget 0.0000, regime 0.0000
 
-### Evaluation qualitative humaine (HITL, 1-5)
+#### Evaluation qualitative humaine (HITL, 1-5)
 
 - N ratings : 0
 - Pertinence nutrition : 0.00
@@ -109,10 +116,47 @@ Top classes (precision / rappel / F1 / support) :
 
 ![Distribution latence LLM](docs/llm_latency_distribution.png)
 
+### Niveau pipeline (DeCRIM-light + cache bypass)
+
+> Numeros a peupler par le runner. Lancer
+> `python scripts/eval_metrics.py llm --n-generations 30 --n-constraint-plans 30`
+> avec Ollama et PostgreSQL accessibles (settings.ollama_host /
+> settings.database_url). Le runner ecrit les valeurs reelles sous
+> `docs/metrics.json` -> `llm.pipeline`.
+
+- N generations : 0 (en attente de run)
+- compliance_status full : 0.0000
+- compliance_status partial_budget : 0.0000
+- compliance_status static_fallback : 0.0000
+- abandoned_503 (contraintes infaisables) : 0.0000
+- Par contrainte : allergies 0.0000, budget 0.0000, regime 0.0000
+- Latence : p50 0 ms, p95 0 ms
+- Distribution retries : (vide)
+
+### Comparaison naive vs pipeline
+
+Une fois la passe pipeline executee, on attend :
+
+- **constraint_satisfaction full > naive** : la boucle DeCRIM-light retire
+  les ingredients allergenes via retry partiel (uniquement le repas violant)
+  et reduit le budget des jours qui depassent via retry complet du jour.
+  Le fallback hierarchique apporte un filet de securite supplementaire.
+- **abandoned_503 faible** : seuls les couples (regime, allergies) reellement
+  infaisables (ex. vegan strict + allergie a tous les substituts vegetaux)
+  doivent declencher le 503. Sur le pool d'inputs aleatoires, on s'attend
+  a moins de 5% de 503.
+- **Surcout latence p95** : chaque generation peut declencher jusqu'a 4
+  appels Ollama (initial + 2 retries partiels + 1 retry complet en garde-fou).
+  Le ratio pipeline/naive p95 attendu est entre x1.5 et x3.0 sur CPU, selon
+  la frequence des violations.
+- **Repartition par contrainte** : la pipeline doit prioriser allergies/regime
+  (criticite sante) sur le budget. On accepte des `partial_budget` plutot
+  qu'un `static_fallback` quand seul le budget est viole.
+
 ## Discussion
 
 - **Limitations dataset Food-101** : 101 classes academiques, photos cadrees, fond neutre. Tres different des photos prises au telephone (eclairage, angle, plat composite).
 - **Biais du modele** : fine-tune sur Food-101 -> classes hors-distribution (ex : plats francais traditionnels, repas ethniques specifiques) sont systematiquement misclassifies vers la classe la plus proche visuellement.
 - **Cas d'echec frequents** : plats mixtes (assiette avec plusieurs aliments), decoupes inhabituelles, photos en faible luminosite, gros plans non cadres.
-- **LLM** : la latence p95 sur CPU reste contraignante ; le fallback statique garantit une UX correcte hors disponibilite Ollama. Les violations de contraintes proviennent souvent du regime alimentaire (vegan/sans gluten moins bien respectes que les allergies).
+- **LLM** : la latence p95 sur CPU reste contraignante ; le fallback statique garantit une UX correcte hors disponibilite Ollama. Avant slice 7, les violations de contraintes provenaient souvent du regime alimentaire (vegan/sans gluten moins bien respectes que les allergies). Le pipeline DeCRIM-light cible explicitement ces violations : retry partiel sur allergie/regime (n'invalide pas tout le plan), retry complet du jour sur budget, fallback hierarchique sur la matrice statique.
 

--- a/scripts/eval/llm_metrics.py
+++ b/scripts/eval/llm_metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import math
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,12 +18,16 @@ __all__ = [
     "ConstraintSpec",
     "GenerationOutcome",
     "HitlSummary",
+    "PipelineOutcome",
+    "by_constraint_satisfaction",
     "check_plan_constraints",
+    "compliance_status_breakdown",
     "constraint_satisfaction_rate",
     "fallback_rate",
     "json_validity_rate",
     "latency_percentiles",
     "load_hitl_ratings",
+    "retry_count_distribution",
 ]
 
 
@@ -45,6 +50,24 @@ class ConstraintCheck:
 
     def all_satisfied(self) -> bool:
         return self.allergies_absent and self.budget_respected and self.diet_respected
+
+
+@dataclass(frozen=True)
+class PipelineOutcome:
+    """Resultat d'une generation via le pipeline complet (DeCRIM-light + retry).
+
+    compliance_status : 'full' / 'partial_budget' / 'static_fallback' / 'abandoned_503'
+                        ('abandoned_503' = InfeasibleConstraintsError -> HTTP 503).
+    ollama_calls      : nombre total d'appels Ollama (initial + retries internes).
+                        retries = max(0, ollama_calls - 1).
+    latency_ms        : latence wallclock end-to-end (cache + LLM + persist).
+    constraint_check  : evaluation finale du plan retourne (None si 503).
+    """
+
+    compliance_status: str
+    ollama_calls: int
+    latency_ms: float
+    constraint_check: ConstraintCheck | None
 
 
 def latency_percentiles(latencies_ms: list[float]) -> dict[str, float]:
@@ -83,6 +106,54 @@ def constraint_satisfaction_rate(checks: list[ConstraintCheck]) -> float:
     if not checks:
         return 0.0
     return sum(1 for c in checks if c.all_satisfied()) / len(checks)
+
+
+def by_constraint_satisfaction(checks: list[ConstraintCheck]) -> dict[str, float]:
+    """Taux de respect par contrainte individuelle (allergies / budget / diet).
+
+    Utile pour comparer naive et pipeline : la pipeline DeCRIM-light met le
+    paquet sur allergies/diet (retries cibles + fallback) et tolere des
+    relachements budget.
+    """
+    if not checks:
+        return {"allergies": 0.0, "budget": 0.0, "diet": 0.0}
+    n = len(checks)
+    return {
+        "allergies": sum(1 for c in checks if c.allergies_absent) / n,
+        "budget": sum(1 for c in checks if c.budget_respected) / n,
+        "diet": sum(1 for c in checks if c.diet_respected) / n,
+    }
+
+
+def compliance_status_breakdown(outcomes: list[PipelineOutcome]) -> dict[str, float]:
+    """Decoupe les outcomes pipeline par compliance_status (en taux).
+
+    Renvoie 4 cles : full / partial_budget / static_fallback / abandoned_503.
+    Toutes presentes meme a zero pour faciliter le rendu Markdown.
+    """
+    base = {
+        "full": 0.0,
+        "partial_budget": 0.0,
+        "static_fallback": 0.0,
+        "abandoned_503": 0.0,
+    }
+    if not outcomes:
+        return base
+    n = len(outcomes)
+    for o in outcomes:
+        if o.compliance_status in base:
+            base[o.compliance_status] += 1
+    return {k: v / n for k, v in base.items()}
+
+
+def retry_count_distribution(outcomes: list[PipelineOutcome]) -> dict[str, int]:
+    """Histogramme retry_count -> nb de generations.
+
+    retries = max(0, ollama_calls - 1) : 0 retry = 1 appel = plan accepte direct.
+    Cles en string pour serialisation JSON-friendly.
+    """
+    counts = Counter(max(0, o.ollama_calls - 1) for o in outcomes)
+    return {str(k): counts[k] for k in sorted(counts)}
 
 
 def check_plan_constraints(

--- a/scripts/eval/llm_runner.py
+++ b/scripts/eval/llm_runner.py
@@ -247,13 +247,13 @@ async def _count_ollama_calls(orchestrator_module: Any) -> AsyncIterator[dict[st
 
 
 @contextlib.contextmanager
-def _ephemeral_session(SessionLocal: Any) -> Any:
+def _ephemeral_session(session_factory: Any) -> Any:
     """Session SQLAlchemy ouverte/fermee proprement, rollback en sortie.
 
     On rollback en fin de boucle : on ne veut pas polluer la BDD avec les
     plans d'eval (les resultats sont aggreges en memoire et exportes en JSON).
     """
-    db = SessionLocal()
+    db = session_factory()
     try:
         yield db
     finally:

--- a/scripts/eval/llm_runner.py
+++ b/scripts/eval/llm_runner.py
@@ -1,17 +1,26 @@
 """
-Runner LLM : lance N generations Ollama (gemma3:4b) et calcule les 5 metriques
-exigees : validite JSON 1er essai, latence p50/p95/max, taux de fallback,
-respect simultanee allergies+budget+regime, et resume HITL si CSV present.
+Runner LLM : compare deux niveaux de pipeline sur les memes inputs aleatoires.
 
-Necessite Ollama accessible (settings.ollama_host) et le modele gemma3:4b pull.
+  - llm.naive    : LLM nu (gemma3:4b sans DeCRIM-light), tel qu'utilise avant slice 7.
+                   Mesure validite JSON, latence, fallback, respect simultanee
+                   allergies+budget+regime, et HITL.
+  - llm.pipeline : pipeline complet (slice 7) generate_plan + decrim_retry_orchestrator.
+                   Mesure compliance_status (full / partial_budget / static_fallback /
+                   abandoned_503), latence, retries Ollama, respect par contrainte.
+
+Necessite :
+  - Ollama accessible (settings.ollama_host) et le modele gemma3:4b pull
+  - PostgreSQL accessible (settings.database_url) avec migrations V11+ jouees
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import random
 import time
+from collections.abc import AsyncIterator
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -30,12 +39,16 @@ from scripts.eval.llm_metrics import (
     ConstraintCheck,
     ConstraintSpec,
     GenerationOutcome,
+    PipelineOutcome,
+    by_constraint_satisfaction,
     check_plan_constraints,
+    compliance_status_breakdown,
     constraint_satisfaction_rate,
     fallback_rate,
     json_validity_rate,
     latency_percentiles,
     load_hitl_ratings,
+    retry_count_distribution,
 )
 from scripts.eval.plotting import save_latency_distribution_png
 
@@ -64,8 +77,35 @@ async def run_llm_eval(
     seed: int,
     output_dir: Path,
 ) -> dict[str, Any]:
-    """Renvoie un payload llm pour metrics.json."""
-    logger.info("llm : %d generations en conditions normales", n_generations)
+    """Renvoie un payload llm pour metrics.json avec deux niveaux : naive + pipeline."""
+    naive_payload = await _run_naive_eval(
+        n_generations=n_generations,
+        n_constraint_plans=n_constraint_plans,
+        hitl_csv=hitl_csv,
+        seed=seed,
+        output_dir=output_dir,
+    )
+
+    pipeline_payload = await _run_pipeline_eval(
+        n=n_constraint_plans,
+        seed=seed,
+    )
+
+    return {"naive": naive_payload, "pipeline": pipeline_payload}
+
+
+# Niveau naive : LLM nu (gemma3:4b sans DeCRIM-light, sans cache, sans persistance).
+
+
+async def _run_naive_eval(
+    n_generations: int,
+    n_constraint_plans: int,
+    hitl_csv: Path,
+    seed: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Eval du LLM nu : pas de retry sur contraintes, pas de fallback hierarchique."""
+    logger.info("llm.naive : %d generations en conditions normales", n_generations)
     outcomes = await _run_generations(n_generations, with_constraints=False, seed=seed)
 
     constraint_outcomes, constraint_checks = await _run_constraint_eval(
@@ -78,13 +118,17 @@ async def run_llm_eval(
     if successful_latencies:
         save_latency_distribution_png(successful_latencies, latency_png)
 
+    latency = latency_percentiles(successful_latencies)
     payload: dict[str, Any] = {
         "n_generations": len(outcomes),
         "json_validity_rate": json_validity_rate(outcomes),
         "fallback_rate": fallback_rate(outcomes),
-        "latency": latency_percentiles(successful_latencies),
-        "constraint_satisfaction_rate": constraint_satisfaction_rate(constraint_checks),
+        "latency_p50_ms": latency["p50_ms"],
+        "latency_p95_ms": latency["p95_ms"],
+        "latency_max_ms": latency["max_ms"],
+        "constraint_satisfaction": constraint_satisfaction_rate(constraint_checks),
         "constraint_n_plans": len(constraint_checks),
+        "by_constraint": by_constraint_satisfaction(constraint_checks),
         "latency_distribution_png": str(latency_png) if successful_latencies else None,
     }
 
@@ -106,7 +150,128 @@ async def run_llm_eval(
     return payload
 
 
-# --- internes : generations brutes via Ollama --------------------------------
+# Niveau pipeline : generate_plan complet (DeCRIM-light + cache bypass + persistance).
+
+
+async def _run_pipeline_eval(n: int, seed: int) -> dict[str, Any]:
+    """Genere n plans via le pipeline complet, memes inputs que _run_constraint_eval.
+
+    Compte les compliance_status, mesure latence + retries Ollama, et calcule
+    le respect par contrainte (allergies / budget / diet) sur les plans rendus.
+    """
+    # Imports tardifs : ces modules touchent a la BDD et a Ollama, on ne les
+    # charge que dans le pipeline eval (le naive eval reste DB-less).
+    from app.db.session import SessionLocal
+    from app.services import decrim_retry_orchestrator
+    from app.services.decrim_retry_orchestrator import InfeasibleConstraintsError
+    from app.services.fallback_loader import load_fallback_plan
+    from app.services.llm_client import generate_plan
+
+    logger.info("llm.pipeline : %d generations via generate_plan (bypass_cache)", n)
+
+    pipeline_outcomes: list[PipelineOutcome] = []
+    rng = random.Random(seed + 1)  # Meme seed que _run_constraint_eval -> memes inputs.
+
+    for i in range(n):
+        inputs = _random_inputs(rng, i, with_constraints=True)
+        spec = _spec_from_inputs(inputs)
+
+        async with _count_ollama_calls(decrim_retry_orchestrator) as call_counter:
+            start = time.monotonic()
+            try:
+                with _ephemeral_session(SessionLocal) as db:
+                    plan, status, _warnings = await generate_plan(
+                        inputs,
+                        db,
+                        bypass_cache=True,
+                        fallback_loader=load_fallback_plan,
+                    )
+                latency_ms = (time.monotonic() - start) * 1000
+                check = check_plan_constraints(plan, spec)
+                pipeline_outcomes.append(
+                    PipelineOutcome(
+                        compliance_status=status.value,
+                        ollama_calls=call_counter["calls"],
+                        latency_ms=latency_ms,
+                        constraint_check=check,
+                    )
+                )
+            except InfeasibleConstraintsError:
+                latency_ms = (time.monotonic() - start) * 1000
+                pipeline_outcomes.append(
+                    PipelineOutcome(
+                        compliance_status="abandoned_503",
+                        ollama_calls=call_counter["calls"],
+                        latency_ms=latency_ms,
+                        constraint_check=None,
+                    )
+                )
+
+    breakdown = compliance_status_breakdown(pipeline_outcomes)
+    latencies = [o.latency_ms for o in pipeline_outcomes]
+    latency = latency_percentiles(latencies)
+    checks = [o.constraint_check for o in pipeline_outcomes if o.constraint_check]
+
+    return {
+        "n_generations": n,
+        "constraint_satisfaction": breakdown["full"],
+        "partial_compliance": breakdown["partial_budget"],
+        "static_fallback": breakdown["static_fallback"],
+        "abandoned_503": breakdown["abandoned_503"],
+        "by_constraint": by_constraint_satisfaction(checks),
+        "latency_p50_ms": latency["p50_ms"],
+        "latency_p95_ms": latency["p95_ms"],
+        "retry_count_distribution": retry_count_distribution(pipeline_outcomes),
+    }
+
+
+@contextlib.asynccontextmanager
+async def _count_ollama_calls(orchestrator_module: Any) -> AsyncIterator[dict[str, int]]:
+    """Wrappe `_ollama_generate` du module orchestrator pour compter les appels.
+
+    Reset a 0 a l'entree ; restauration de l'original a la sortie. Compatible
+    avec une seule generation a la fois (l'eval est sequentielle).
+    """
+    counter: dict[str, int] = {"calls": 0}
+    original = orchestrator_module._ollama_generate
+
+    async def wrapper(prompt: str, schema: dict[str, Any]) -> str:
+        counter["calls"] += 1
+        return await original(prompt, schema)
+
+    orchestrator_module._ollama_generate = wrapper
+    try:
+        yield counter
+    finally:
+        orchestrator_module._ollama_generate = original
+
+
+@contextlib.contextmanager
+def _ephemeral_session(SessionLocal: Any) -> Any:
+    """Session SQLAlchemy ouverte/fermee proprement, rollback en sortie.
+
+    On rollback en fin de boucle : on ne veut pas polluer la BDD avec les
+    plans d'eval (les resultats sont aggreges en memoire et exportes en JSON).
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.rollback()
+        db.close()
+
+
+def _spec_from_inputs(inputs: PlanInputs) -> ConstraintSpec:
+    return ConstraintSpec(
+        allergies=list(inputs.allergies),
+        max_daily_budget_eur=float(inputs.budget_per_day)
+        if inputs.budget_per_day
+        else None,
+        diet_type=inputs.diet_type,
+    )
+
+
+# --- internes : generations brutes via Ollama (niveau naive) -----------------
 
 
 async def _run_generations(
@@ -134,13 +299,7 @@ async def _run_constraint_eval(
     rng = random.Random(seed + 1)  # Decorele du seed des generations 'normales'
     for i in range(n):
         inputs = _random_inputs(rng, i, with_constraints=True)
-        spec = ConstraintSpec(
-            allergies=list(inputs.allergies),
-            max_daily_budget_eur=float(inputs.budget_per_day)
-            if inputs.budget_per_day
-            else None,
-            diet_type=inputs.diet_type,
-        )
+        spec = _spec_from_inputs(inputs)
         outcome, plan = await _call_ollama_for_eval(inputs)
         outcomes.append(outcome)
         if plan is not None and not outcome.used_fallback:

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -115,93 +115,91 @@ def _render_llm_section(data: dict[str, Any]) -> list[str]:
         naive = data
 
     if naive:
-        out.append("### Niveau naive (LLM nu, sans DeCRIM-light)")
-        out.append("")
-        out.append(
-            f"- Taux de validite JSON (1er essai) : "
-            f"{naive.get('json_validity_rate', 0.0):.4f}"
-        )
-        out.append(
-            f"- Taux d'invocation Fallback : {naive.get('fallback_rate', 0.0):.4f}"
-        )
-        out.append(
-            f"- Latence : p50 {naive.get('latency_p50_ms', 0.0):.0f} ms, "
-            f"p95 {naive.get('latency_p95_ms', 0.0):.0f} ms, "
-            f"max {naive.get('latency_max_ms', 0.0):.0f} ms"
-        )
-        out.append(
-            f"- Respect simultanee allergies + budget + regime : "
-            f"{naive.get('constraint_satisfaction', 0.0):.4f}"
-        )
-        by_c = naive.get("by_constraint") or {}
-        if by_c:
-            out.append(
-                f"- Par contrainte : allergies {by_c.get('allergies', 0.0):.4f}, "
-                f"budget {by_c.get('budget', 0.0):.4f}, "
-                f"regime {by_c.get('diet', 0.0):.4f}"
-            )
-        out.append("")
-
-        hitl = naive.get("hitl") or {}
-        if hitl:
-            out.append("#### Evaluation qualitative humaine (HITL, 1-5)")
-            out.append("")
-            out.append(f"- N ratings : {hitl.get('n_ratings', 0)}")
-            out.append(
-                f"- Pertinence nutrition : {hitl.get('mean_nutrition', 0.0):.2f}"
-            )
-            out.append(f"- Originalite : {hitl.get('mean_originalite', 0.0):.2f}")
-            out.append(f"- Coherence : {hitl.get('mean_coherence', 0.0):.2f}")
-            out.append("")
-
-        latency_png = naive.get("latency_distribution_png")
-        if latency_png:
-            out.append(f"![Distribution latence LLM]({latency_png})")
-            out.append("")
-
+        out.extend(_render_naive_block(naive))
     if pipeline:
-        out.append("### Niveau pipeline (DeCRIM-light + cache bypass)")
-        out.append("")
-        out.append(
-            f"- N generations : {pipeline.get('n_generations', 0)}"
-        )
-        out.append(
-            f"- compliance_status full : "
-            f"{pipeline.get('constraint_satisfaction', 0.0):.4f}"
-        )
-        out.append(
-            f"- compliance_status partial_budget : "
-            f"{pipeline.get('partial_compliance', 0.0):.4f}"
-        )
-        out.append(
-            f"- compliance_status static_fallback : "
-            f"{pipeline.get('static_fallback', 0.0):.4f}"
-        )
-        out.append(
-            f"- abandoned_503 (contraintes infaisables) : "
-            f"{pipeline.get('abandoned_503', 0.0):.4f}"
-        )
-        by_c = pipeline.get("by_constraint") or {}
-        if by_c:
-            out.append(
-                f"- Par contrainte : allergies {by_c.get('allergies', 0.0):.4f}, "
-                f"budget {by_c.get('budget', 0.0):.4f}, "
-                f"regime {by_c.get('diet', 0.0):.4f}"
-            )
-        out.append(
-            f"- Latence : p50 {pipeline.get('latency_p50_ms', 0.0):.0f} ms, "
-            f"p95 {pipeline.get('latency_p95_ms', 0.0):.0f} ms"
-        )
-        rcd = pipeline.get("retry_count_distribution") or {}
-        if rcd:
-            buckets = ", ".join(f"{k} retry: {v}" for k, v in sorted(rcd.items()))
-            out.append(f"- Distribution retries : {buckets}")
-        out.append("")
-
+        out.extend(_render_pipeline_block(pipeline))
     if naive and pipeline:
         out.extend(_render_naive_vs_pipeline_comparison(naive, pipeline))
 
     return out
+
+
+def _render_naive_block(naive: dict[str, Any]) -> list[str]:
+    out: list[str] = [
+        "### Niveau naive (LLM nu, sans DeCRIM-light)",
+        "",
+        f"- Taux de validite JSON (1er essai) : "
+        f"{naive.get('json_validity_rate', 0.0):.4f}",
+        f"- Taux d'invocation Fallback : {naive.get('fallback_rate', 0.0):.4f}",
+        f"- Latence : p50 {naive.get('latency_p50_ms', 0.0):.0f} ms, "
+        f"p95 {naive.get('latency_p95_ms', 0.0):.0f} ms, "
+        f"max {naive.get('latency_max_ms', 0.0):.0f} ms",
+        f"- Respect simultanee allergies + budget + regime : "
+        f"{naive.get('constraint_satisfaction', 0.0):.4f}",
+    ]
+    by_c = naive.get("by_constraint") or {}
+    if by_c:
+        out.append(_format_by_constraint_line(by_c))
+    out.append("")
+
+    out.extend(_render_hitl_block(naive.get("hitl") or {}))
+
+    latency_png = naive.get("latency_distribution_png")
+    if latency_png:
+        out.append(f"![Distribution latence LLM]({latency_png})")
+        out.append("")
+    return out
+
+
+def _render_hitl_block(hitl: dict[str, Any]) -> list[str]:
+    if not hitl:
+        return []
+    return [
+        "#### Evaluation qualitative humaine (HITL, 1-5)",
+        "",
+        f"- N ratings : {hitl.get('n_ratings', 0)}",
+        f"- Pertinence nutrition : {hitl.get('mean_nutrition', 0.0):.2f}",
+        f"- Originalite : {hitl.get('mean_originalite', 0.0):.2f}",
+        f"- Coherence : {hitl.get('mean_coherence', 0.0):.2f}",
+        "",
+    ]
+
+
+def _render_pipeline_block(pipeline: dict[str, Any]) -> list[str]:
+    out: list[str] = [
+        "### Niveau pipeline (DeCRIM-light + cache bypass)",
+        "",
+        f"- N generations : {pipeline.get('n_generations', 0)}",
+        f"- compliance_status full : "
+        f"{pipeline.get('constraint_satisfaction', 0.0):.4f}",
+        f"- compliance_status partial_budget : "
+        f"{pipeline.get('partial_compliance', 0.0):.4f}",
+        f"- compliance_status static_fallback : "
+        f"{pipeline.get('static_fallback', 0.0):.4f}",
+        f"- abandoned_503 (contraintes infaisables) : "
+        f"{pipeline.get('abandoned_503', 0.0):.4f}",
+    ]
+    by_c = pipeline.get("by_constraint") or {}
+    if by_c:
+        out.append(_format_by_constraint_line(by_c))
+    out.append(
+        f"- Latence : p50 {pipeline.get('latency_p50_ms', 0.0):.0f} ms, "
+        f"p95 {pipeline.get('latency_p95_ms', 0.0):.0f} ms"
+    )
+    rcd = pipeline.get("retry_count_distribution") or {}
+    if rcd:
+        buckets = ", ".join(f"{k} retry: {v}" for k, v in sorted(rcd.items()))
+        out.append(f"- Distribution retries : {buckets}")
+    out.append("")
+    return out
+
+
+def _format_by_constraint_line(by_c: dict[str, Any]) -> str:
+    return (
+        f"- Par contrainte : allergies {by_c.get('allergies', 0.0):.4f}, "
+        f"budget {by_c.get('budget', 0.0):.4f}, "
+        f"regime {by_c.get('diet', 0.0):.4f}"
+    )
 
 
 def _render_naive_vs_pipeline_comparison(

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -106,37 +106,145 @@ def _render_llm_section(data: dict[str, Any]) -> list[str]:
         return []
     out: list[str] = ["## LLM (Ollama gemma3:4b)", ""]
 
-    out.append(
-        f"- Taux de validite JSON (1er essai) : {data.get('json_validity_rate', 0.0):.4f}"
+    naive = data.get("naive") or {}
+    pipeline = data.get("pipeline") or {}
+
+    # Retro-compatibilite : si la cle "naive" n'existe pas, on suppose le format
+    # pre-slice 7 (champs a plat directement sous "llm").
+    if not naive and not pipeline:
+        naive = data
+
+    if naive:
+        out.append("### Niveau naive (LLM nu, sans DeCRIM-light)")
+        out.append("")
+        out.append(
+            f"- Taux de validite JSON (1er essai) : "
+            f"{naive.get('json_validity_rate', 0.0):.4f}"
+        )
+        out.append(
+            f"- Taux d'invocation Fallback : {naive.get('fallback_rate', 0.0):.4f}"
+        )
+        out.append(
+            f"- Latence : p50 {naive.get('latency_p50_ms', 0.0):.0f} ms, "
+            f"p95 {naive.get('latency_p95_ms', 0.0):.0f} ms, "
+            f"max {naive.get('latency_max_ms', 0.0):.0f} ms"
+        )
+        out.append(
+            f"- Respect simultanee allergies + budget + regime : "
+            f"{naive.get('constraint_satisfaction', 0.0):.4f}"
+        )
+        by_c = naive.get("by_constraint") or {}
+        if by_c:
+            out.append(
+                f"- Par contrainte : allergies {by_c.get('allergies', 0.0):.4f}, "
+                f"budget {by_c.get('budget', 0.0):.4f}, "
+                f"regime {by_c.get('diet', 0.0):.4f}"
+            )
+        out.append("")
+
+        hitl = naive.get("hitl") or {}
+        if hitl:
+            out.append("#### Evaluation qualitative humaine (HITL, 1-5)")
+            out.append("")
+            out.append(f"- N ratings : {hitl.get('n_ratings', 0)}")
+            out.append(
+                f"- Pertinence nutrition : {hitl.get('mean_nutrition', 0.0):.2f}"
+            )
+            out.append(f"- Originalite : {hitl.get('mean_originalite', 0.0):.2f}")
+            out.append(f"- Coherence : {hitl.get('mean_coherence', 0.0):.2f}")
+            out.append("")
+
+        latency_png = naive.get("latency_distribution_png")
+        if latency_png:
+            out.append(f"![Distribution latence LLM]({latency_png})")
+            out.append("")
+
+    if pipeline:
+        out.append("### Niveau pipeline (DeCRIM-light + cache bypass)")
+        out.append("")
+        out.append(
+            f"- N generations : {pipeline.get('n_generations', 0)}"
+        )
+        out.append(
+            f"- compliance_status full : "
+            f"{pipeline.get('constraint_satisfaction', 0.0):.4f}"
+        )
+        out.append(
+            f"- compliance_status partial_budget : "
+            f"{pipeline.get('partial_compliance', 0.0):.4f}"
+        )
+        out.append(
+            f"- compliance_status static_fallback : "
+            f"{pipeline.get('static_fallback', 0.0):.4f}"
+        )
+        out.append(
+            f"- abandoned_503 (contraintes infaisables) : "
+            f"{pipeline.get('abandoned_503', 0.0):.4f}"
+        )
+        by_c = pipeline.get("by_constraint") or {}
+        if by_c:
+            out.append(
+                f"- Par contrainte : allergies {by_c.get('allergies', 0.0):.4f}, "
+                f"budget {by_c.get('budget', 0.0):.4f}, "
+                f"regime {by_c.get('diet', 0.0):.4f}"
+            )
+        out.append(
+            f"- Latence : p50 {pipeline.get('latency_p50_ms', 0.0):.0f} ms, "
+            f"p95 {pipeline.get('latency_p95_ms', 0.0):.0f} ms"
+        )
+        rcd = pipeline.get("retry_count_distribution") or {}
+        if rcd:
+            buckets = ", ".join(f"{k} retry: {v}" for k, v in sorted(rcd.items()))
+            out.append(f"- Distribution retries : {buckets}")
+        out.append("")
+
+    if naive and pipeline:
+        out.extend(_render_naive_vs_pipeline_comparison(naive, pipeline))
+
+    return out
+
+
+def _render_naive_vs_pipeline_comparison(
+    naive: dict[str, Any], pipeline: dict[str, Any]
+) -> list[str]:
+    """Section comparative explicite entre naive et pipeline (slice 7).
+
+    Quantifie l'apport du retry DeCRIM-light : delta de constraint_satisfaction,
+    repartition des relachements, surcout en latence.
+    """
+    out = ["### Comparaison naive vs pipeline", ""]
+
+    delta_full = pipeline.get("constraint_satisfaction", 0.0) - naive.get(
+        "constraint_satisfaction", 0.0
     )
-    out.append(f"- Taux d'invocation Fallback : {data.get('fallback_rate', 0.0):.4f}")
-    latency = data.get("latency") or {}
     out.append(
-        f"- Latence : p50 {latency.get('p50_ms', 0.0):.0f} ms, "
-        f"p95 {latency.get('p95_ms', 0.0):.0f} ms, "
-        f"max {latency.get('max_ms', 0.0):.0f} ms"
+        f"- Gain compliance_status full vs naive : {delta_full:+.4f}. "
+        "Un gain positif quantifie l'apport du retry cible (allergie/regime "
+        "partiels, budget complet) et du fallback hierarchique."
     )
-    out.append(
-        f"- Respect simultanee allergies + budget + regime : "
-        f"{data.get('constraint_satisfaction_rate', 0.0):.4f}"
-    )
+
+    naive_by = naive.get("by_constraint") or {}
+    pipe_by = pipeline.get("by_constraint") or {}
+    if naive_by and pipe_by:
+        for key in ("allergies", "budget", "diet"):
+            out.append(
+                f"- Delta {key} : "
+                f"naive {naive_by.get(key, 0.0):.4f} -> "
+                f"pipeline {pipe_by.get(key, 0.0):.4f} "
+                f"({pipe_by.get(key, 0.0) - naive_by.get(key, 0.0):+.4f})"
+            )
+
+    naive_p95 = naive.get("latency_p95_ms", 0.0)
+    pipe_p95 = pipeline.get("latency_p95_ms", 0.0)
+    if naive_p95 and pipe_p95:
+        ratio = pipe_p95 / naive_p95 if naive_p95 else 0.0
+        out.append(
+            f"- Surcout latence p95 : naive {naive_p95:.0f} ms -> "
+            f"pipeline {pipe_p95:.0f} ms (ratio x{ratio:.2f}). "
+            "Le pipeline paie le prix des retries internes pour reduire les "
+            "violations critiques (allergies/regime)."
+        )
     out.append("")
-
-    hitl = data.get("hitl") or {}
-    if hitl:
-        out.append("### Evaluation qualitative humaine (HITL, 1-5)")
-        out.append("")
-        out.append(f"- N ratings : {hitl.get('n_ratings', 0)}")
-        out.append(f"- Pertinence nutrition : {hitl.get('mean_nutrition', 0.0):.2f}")
-        out.append(f"- Originalite : {hitl.get('mean_originalite', 0.0):.2f}")
-        out.append(f"- Coherence : {hitl.get('mean_coherence', 0.0):.2f}")
-        out.append("")
-
-    latency_png = data.get("latency_distribution_png")
-    if latency_png:
-        out.append(f"![Distribution latence LLM]({latency_png})")
-        out.append("")
-
     return out
 
 

--- a/tests/test_meal_plan_api.py
+++ b/tests/test_meal_plan_api.py
@@ -792,6 +792,6 @@ def test_compliance_persisted_to_meal_plans_table(
     ).fetchone()
     assert row is not None
     assert row.compliance_status == "full"
-    # Liste vide en BDD : NULL ou tableau vide selon la version, on accepte
-    # les deux (le contrat client est "compliance_warnings: list" cote API).
-    assert row.compliance_warnings in (None, [])
+    # _persist_plan envoie systematiquement une liste (eventuellement vide)
+    # cote SQLAlchemy : Postgres stocke un ARRAY vide, jamais NULL.
+    assert row.compliance_warnings == []

--- a/tests/test_meal_plan_api.py
+++ b/tests/test_meal_plan_api.py
@@ -639,3 +639,159 @@ def test_missing_diet_type_returns_422(
         headers={"Authorization": f"Bearer {valid_jwt(user_id=903)}"},
     )
     assert response.status_code == 422
+
+
+# Slice 7 PRD #45 : compliance_status + compliance_warnings + 503 infaisable.
+
+
+def test_response_includes_compliance_status_and_warnings_on_full(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Plan LLM 100% conforme : compliance_status='full', warnings vides."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=1000)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["compliance_status"] == "full"
+    assert body["compliance_warnings"] == []
+
+
+def test_response_includes_static_fallback_when_ollama_down(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+) -> None:
+    """Ollama injoignable apres tous les retries : status=static_fallback + warning."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        503, json={"error": "down"}
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 7,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=1001)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["compliance_status"] == "static_fallback"
+    assert body["compliance_warnings"]
+    assert any("statique" in w.lower() for w in body["compliance_warnings"])
+
+
+def test_infeasible_constraints_returns_503_with_explicit_body(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allergie + plan statique allergene : DeCRIM-light leve, router renvoie 503."""
+    bad_meal = {
+        "name": "Pad thai",
+        "macros": {
+            "calories": 500,
+            "protein_g": 25.0,
+            "carbs_g": 50.0,
+            "fat_g": 15.0,
+        },
+        "ingredients": ["sauce aux arachides", "nouilles"],
+        "est_budget_eur": 5.0,
+        "prep_time_min": 15,
+    }
+    bad_plan = {
+        "fallback": False,
+        "days": [{"day": 1, "meals": [bad_meal]}],
+    }
+    bad_meal_resp = {"response": json.dumps(bad_meal), "done": True}
+    # Sequence DeCRIM-light : initial allergene + 2 retries partiels allergenes
+    # + retry plan complet (garde-fou) allergene -> fallback statique allergene -> 503.
+    mock_ollama.post(re.compile(r".*/api/generate$")).mock(
+        side_effect=[
+            httpx.Response(200, json=_ollama_payload(bad_plan)),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=bad_meal_resp),
+            httpx.Response(200, json=_ollama_payload(bad_plan)),
+        ]
+    )
+    # On force le plan statique a etre allergene aussi : la combinaison est
+    # vraiment infaisable.
+    monkeypatch.setattr(
+        "app.services.decrim_retry_orchestrator.load_fallback_plan",
+        lambda _goal, _diet: bad_plan,
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": ["arachides"],
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=1002)}"},
+    )
+
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["infeasible"] is True
+    assert "infaisables" in body["detail"].lower()
+    assert "allergies" in body["detail"].lower()
+
+
+def test_compliance_persisted_to_meal_plans_table(
+    client: TestClient,
+    valid_jwt: Callable[..., str],
+    mock_ollama: respx.MockRouter,
+    db_session: Session,
+) -> None:
+    """compliance_status / compliance_warnings sont ecrits dans meal_plans."""
+    mock_ollama.post(re.compile(r".*/api/generate$")).respond(
+        200, json=_ollama_payload(_valid_plan())
+    )
+
+    response = client.post(
+        "/api/v1/generate-meal-plan",
+        json={
+            "health_goal": "balance",
+            "diet_type": "omnivore",
+            "duration_days": 1,
+            "allergies": [],
+            "budget_eur_per_day": 15,
+        },
+        headers={"Authorization": f"Bearer {valid_jwt(user_id=1003)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    row = db_session.execute(
+        text(
+            "SELECT compliance_status, compliance_warnings "
+            "FROM meal_plans WHERE user_id = 1003"
+        )
+    ).fetchone()
+    assert row is not None
+    assert row.compliance_status == "full"
+    # Liste vide en BDD : NULL ou tableau vide selon la version, on accepte
+    # les deux (le contrat client est "compliance_warnings: list" cote API).
+    assert row.compliance_warnings in (None, [])

--- a/tests/unit/test_eval_llm_metrics.py
+++ b/tests/unit/test_eval_llm_metrics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from app.models.schemas import FallbackMealPlan
 from scripts.eval.llm_metrics import (
     ConstraintCheck,
@@ -238,17 +240,17 @@ def test_compliance_status_breakdown_decodes_outcomes() -> None:
 
     result = compliance_status_breakdown(outcomes)
 
-    assert result["full"] == 0.4
-    assert result["partial_budget"] == 0.2
-    assert result["static_fallback"] == 0.2
-    assert result["abandoned_503"] == 0.2
+    assert result["full"] == pytest.approx(0.4)
+    assert result["partial_budget"] == pytest.approx(0.2)
+    assert result["static_fallback"] == pytest.approx(0.2)
+    assert result["abandoned_503"] == pytest.approx(0.2)
 
 
 def test_compliance_status_breakdown_empty_returns_zeros_with_all_keys() -> None:
     result = compliance_status_breakdown([])
 
     assert set(result) == {"full", "partial_budget", "static_fallback", "abandoned_503"}
-    assert all(v == 0.0 for v in result.values())
+    assert all(v == pytest.approx(0.0) for v in result.values())
 
 
 def test_retry_count_distribution_buckets_by_call_count() -> None:

--- a/tests/unit/test_eval_llm_metrics.py
+++ b/tests/unit/test_eval_llm_metrics.py
@@ -7,12 +7,16 @@ from scripts.eval.llm_metrics import (
     ConstraintCheck,
     ConstraintSpec,
     GenerationOutcome,
+    PipelineOutcome,
+    by_constraint_satisfaction,
     check_plan_constraints,
+    compliance_status_breakdown,
     constraint_satisfaction_rate,
     fallback_rate,
     json_validity_rate,
     latency_percentiles,
     load_hitl_ratings,
+    retry_count_distribution,
 )
 
 
@@ -178,6 +182,98 @@ def test_check_plan_constraints_vegan_rejects_animal_ingredients() -> None:
 
     assert check_plan_constraints(plan_meat, spec).diet_respected is False
     assert check_plan_constraints(plan_vegan, spec).diet_respected is True
+
+
+def _pipeline_outcome(
+    *,
+    compliance_status: str = "full",
+    ollama_calls: int = 1,
+    latency_ms: float = 800.0,
+    constraint_check: ConstraintCheck | None = None,
+) -> PipelineOutcome:
+    return PipelineOutcome(
+        compliance_status=compliance_status,
+        ollama_calls=ollama_calls,
+        latency_ms=latency_ms,
+        constraint_check=constraint_check,
+    )
+
+
+def test_by_constraint_satisfaction_splits_per_constraint() -> None:
+    # 4 plans : 3 sans allergene, 2 dans le budget, 4 conformes au regime.
+    checks = [
+        ConstraintCheck(
+            allergies_absent=True, budget_respected=True, diet_respected=True
+        ),
+        ConstraintCheck(
+            allergies_absent=True, budget_respected=False, diet_respected=True
+        ),
+        ConstraintCheck(
+            allergies_absent=False, budget_respected=True, diet_respected=True
+        ),
+        ConstraintCheck(
+            allergies_absent=True, budget_respected=False, diet_respected=True
+        ),
+    ]
+
+    result = by_constraint_satisfaction(checks)
+
+    assert result == {"allergies": 0.75, "budget": 0.5, "diet": 1.0}
+
+
+def test_by_constraint_satisfaction_empty_returns_zeros() -> None:
+    result = by_constraint_satisfaction([])
+
+    assert result == {"allergies": 0.0, "budget": 0.0, "diet": 0.0}
+
+
+def test_compliance_status_breakdown_decodes_outcomes() -> None:
+    outcomes = [
+        _pipeline_outcome(compliance_status="full"),
+        _pipeline_outcome(compliance_status="full"),
+        _pipeline_outcome(compliance_status="partial_budget"),
+        _pipeline_outcome(compliance_status="static_fallback"),
+        _pipeline_outcome(compliance_status="abandoned_503"),
+    ]
+
+    result = compliance_status_breakdown(outcomes)
+
+    assert result["full"] == 0.4
+    assert result["partial_budget"] == 0.2
+    assert result["static_fallback"] == 0.2
+    assert result["abandoned_503"] == 0.2
+
+
+def test_compliance_status_breakdown_empty_returns_zeros_with_all_keys() -> None:
+    result = compliance_status_breakdown([])
+
+    assert set(result) == {"full", "partial_budget", "static_fallback", "abandoned_503"}
+    assert all(v == 0.0 for v in result.values())
+
+
+def test_retry_count_distribution_buckets_by_call_count() -> None:
+    # ollama_calls : 1 -> 0 retry, 2 -> 1 retry, 4 -> 3 retries.
+    outcomes = [
+        _pipeline_outcome(ollama_calls=1),
+        _pipeline_outcome(ollama_calls=1),
+        _pipeline_outcome(ollama_calls=2),
+        _pipeline_outcome(ollama_calls=4),
+        _pipeline_outcome(ollama_calls=1),
+    ]
+
+    result = retry_count_distribution(outcomes)
+
+    assert result == {"0": 3, "1": 1, "3": 1}
+
+
+def test_retry_count_distribution_clamps_to_zero_minimum() -> None:
+    # ollama_calls=0 ne devrait pas arriver, mais on clampe pour ne jamais
+    # produire de retry negatif (un Counter avec key=-1 surprendrait le lecteur).
+    outcomes = [_pipeline_outcome(ollama_calls=0)]
+
+    result = retry_count_distribution(outcomes)
+
+    assert result == {"0": 1}
 
 
 def test_load_hitl_ratings_aggregates_means(tmp_path: Path) -> None:

--- a/tests/unit/test_eval_report.py
+++ b/tests/unit/test_eval_report.py
@@ -42,17 +42,42 @@ def test_render_metrics_md_includes_required_sections(tmp_path: Path) -> None:
             },
         },
         "llm": {
-            "json_validity_rate": 0.94,
-            "fallback_rate": 0.04,
-            "latency": {"p50_ms": 800.0, "p95_ms": 1500.0, "max_ms": 3000.0},
-            "constraint_satisfaction_rate": 0.87,
-            "hitl": {
-                "n_ratings": 20,
-                "mean_nutrition": 4.1,
-                "mean_originalite": 3.2,
-                "mean_coherence": 4.0,
+            "naive": {
+                "n_generations": 30,
+                "json_validity_rate": 0.94,
+                "fallback_rate": 0.04,
+                "latency_p50_ms": 800.0,
+                "latency_p95_ms": 1500.0,
+                "latency_max_ms": 3000.0,
+                "constraint_satisfaction": 0.87,
+                "by_constraint": {
+                    "allergies": 0.5,
+                    "budget": 0.6,
+                    "diet": 0.4,
+                },
+                "hitl": {
+                    "n_ratings": 20,
+                    "mean_nutrition": 4.1,
+                    "mean_originalite": 3.2,
+                    "mean_coherence": 4.0,
+                },
+                "latency_distribution_png": "docs/llm_latency.png",
             },
-            "latency_distribution_png": "docs/llm_latency.png",
+            "pipeline": {
+                "n_generations": 30,
+                "constraint_satisfaction": 0.85,
+                "partial_compliance": 0.10,
+                "static_fallback": 0.03,
+                "abandoned_503": 0.02,
+                "by_constraint": {
+                    "allergies": 1.0,
+                    "budget": 0.85,
+                    "diet": 1.0,
+                },
+                "latency_p50_ms": 1200.0,
+                "latency_p95_ms": 2500.0,
+                "retry_count_distribution": {"0": 25, "1": 3, "2": 2},
+            },
         },
     }
     out = tmp_path / "metrics.md"
@@ -71,7 +96,11 @@ def test_render_metrics_md_includes_required_sections(tmp_path: Path) -> None:
     assert "## Discussion" in content
     # Chiffres bruts
     assert "0.71" in content or "71" in content  # accuracy
-    assert "1500" in content or "1.5" in content  # p95
+    assert "1500" in content or "1.5" in content  # p95 naive
+    # Slice 7 : niveau pipeline + comparaison naive vs pipeline
+    assert "naive" in content.lower()
+    assert "pipeline" in content.lower()
+    assert "Comparaison" in content
     # Embed des PNGs
     assert "docs/confusion_matrix_food101.png" in content
     assert "docs/llm_latency.png" in content

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -14,6 +14,7 @@ from app.models.schemas import (
     FallbackMealPlan,
     PlanInputs,
 )
+from app.services.decrim_retry_orchestrator import ComplianceStatus
 from app.services.llm_client import (
     compute_inputs_hash,
     generate_plan,
@@ -106,12 +107,14 @@ async def test_generate_plan_success_first_try(
         200, json=_ollama_response(_valid_plan_dict())
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, status, warnings = await generate_plan(inputs, db_session)
 
     assert isinstance(plan, FallbackMealPlan)
     assert plan.fallback is False
     assert _meal_calories(plan) == 1800
     assert plan.days[0].meals[0].name == "Salade poulet"
+    assert status is ComplianceStatus.full
+    assert warnings == []
 
 
 @pytest.mark.asyncio
@@ -123,7 +126,7 @@ async def test_generate_plan_persists_with_inputs_hash(
         200, json=_ollama_response(_valid_plan_dict())
     )
 
-    await generate_plan(inputs, db_session)
+    _plan, _status, _warnings = await generate_plan(inputs, db_session)
 
     row = db_session.execute(
         text("SELECT user_id, inputs_hash, plan FROM meal_plans WHERE user_id = :uid"),
@@ -144,7 +147,7 @@ async def test_generate_plan_calls_ollama_with_json_format(
         200, json=_ollama_response(_valid_plan_dict())
     )
 
-    await generate_plan(inputs, db_session)
+    _plan, _status, _warnings = await generate_plan(inputs, db_session)
 
     assert route.called
     body = json.loads(route.calls.last.request.content)
@@ -169,10 +172,11 @@ async def test_generate_plan_retries_after_first_failure(
     ]
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=responses)
 
-    plan = await generate_plan(inputs, db_session)
+    plan, status, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is False
     assert _meal_calories(plan) == 1800
+    assert status is ComplianceStatus.full
 
 
 @pytest.mark.asyncio
@@ -186,7 +190,7 @@ async def test_generate_plan_retries_on_invalid_json(
     ]
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(side_effect=responses)
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is False
     assert plan.days[0].day == 1
@@ -231,12 +235,16 @@ async def test_generate_plan_falls_back_after_max_attempts(
             ],
         }
 
-    plan = await generate_plan(inputs, db_session, fallback_loader=loader)
+    plan, status, warnings = await generate_plan(
+        inputs, db_session, fallback_loader=loader
+    )
 
     assert plan.fallback is True
     assert _meal_calories(plan) == 600
     assert plan.days[0].meals[0].name == "Plan de secours"
     assert fallback_calls == [("weight_loss", "")]
+    assert status is ComplianceStatus.static_fallback
+    assert warnings  # warning explicitant Ollama injoignable
 
 
 @pytest.mark.asyncio
@@ -248,7 +256,7 @@ async def test_generate_plan_makes_exactly_three_attempts_before_fallback(
         500, json={"error": "boom"}
     )
 
-    plan = await generate_plan(
+    plan, _, _ = await generate_plan(
         inputs, db_session, fallback_loader=lambda *_: {"fallback": True, "days": []}
     )
 
@@ -265,7 +273,7 @@ async def test_generate_plan_fallback_without_loader_returns_empty_plan(
         500, json={"error": "boom"}
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is True
     assert plan.days == []
@@ -298,7 +306,7 @@ async def test_generate_plan_returns_cached_without_calling_ollama(
         200, json=_ollama_response(_valid_plan_dict())
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert _meal_calories(plan) == 9999
     assert route.call_count == 0
@@ -329,7 +337,7 @@ async def test_generate_plan_ignores_cache_older_than_seven_days(
         200, json=_ollama_response(fresh)
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert _meal_calories(plan) == 1234
 
@@ -359,7 +367,7 @@ async def test_generate_plan_bypass_cache_calls_ollama_even_with_hit(
         200, json=_ollama_response(fresh)
     )
 
-    plan = await generate_plan(inputs, db_session, bypass_cache=True)
+    plan, _, _ = await generate_plan(inputs, db_session, bypass_cache=True)
 
     assert _meal_calories(plan) == 4242
     assert route.call_count == 1
@@ -387,17 +395,19 @@ async def test_generate_plan_rejects_plan_with_allergic_ingredient(
     bad = _valid_plan_dict()
     # Le plan contient un ingredient interdit -> validation metier doit rejeter.
     bad["days"][0]["meals"][0]["ingredients"] = ["sauce aux arachides", "riz"]
-    good = _valid_plan_dict()
+    good_meal = _valid_plan_dict()["days"][0]["meals"][0]
+    # 1er appel : plan complet allergene. 2eme : retry partiel sur le repas
+    # violant uniquement -> reponse JSON Meal (pas le plan entier).
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(
         side_effect=[
             httpx.Response(200, json=_ollama_response(bad)),
-            httpx.Response(200, json=_ollama_response(good)),
+            httpx.Response(200, json=_ollama_response(good_meal)),
         ]
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
-    # Le second essai (sans allergene) est accepte.
+    # Le retry partiel (Meal seul) est accepte.
     assert plan.fallback is False
     assert all(
         "arachide" not in ing.lower()
@@ -426,7 +436,7 @@ async def test_generate_plan_does_not_false_positive_lait_in_laitue(
         200, json=_ollama_response(safe)
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is False
     assert route.call_count == 1  # accepte du premier coup, aucun retry
@@ -446,15 +456,15 @@ async def test_generate_plan_rejects_allergen_with_accents(
     )
     bad = _valid_plan_dict()
     bad["days"][0]["meals"][0]["ingredients"] = ["Lait écrémé", "céréales"]
-    good = _valid_plan_dict()
+    good_meal = _valid_plan_dict()["days"][0]["meals"][0]
     mock_ollama.post(re.compile(r".*/api/generate$")).mock(
         side_effect=[
             httpx.Response(200, json=_ollama_response(bad)),
-            httpx.Response(200, json=_ollama_response(good)),
+            httpx.Response(200, json=_ollama_response(good_meal)),
         ]
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is False
     assert all(
@@ -479,7 +489,7 @@ async def test_generate_plan_rejects_invalid_pydantic_structure(
         ]
     )
 
-    plan = await generate_plan(inputs, db_session)
+    plan, _, _ = await generate_plan(inputs, db_session)
 
     assert plan.fallback is False
 
@@ -508,9 +518,11 @@ async def test_generate_plan_semaphore_limits_concurrent_ollama_calls(
         PlanInputs(user_id=50 + i, objective="balance", duration_days=1)
         for i in range(4)
     ]
-    plans = await asyncio.gather(*(generate_plan(i, db_session) for i in inputs_list))
+    results = await asyncio.gather(
+        *(generate_plan(i, db_session) for i in inputs_list)
+    )
 
-    assert all(p.fallback is False for p in plans)
+    assert all(plan.fallback is False for plan, _, _ in results)
     assert max_observed >= 2  # parallelisme effectif
     assert max_observed <= 2  # bornage du semaphore
 


### PR DESCRIPTION
Closes #53

## Summary

Slice 7 PRD #45 : on branche le DeCRIM-light orchestrator (slice 6) dans le pipeline `/generate-meal-plan`, on expose le statut de conformite a l'API et on instrumente l'eval pour comparer LLM nu vs pipeline complet sur les memes inputs.

- `llm_client.generate_plan` wrappe `decrim_retry_orchestrator.generate_with_retry` (cache + flakiness Ollama + persistance + fallback applicatif), retourne `(plan, ComplianceStatus, list[str])`.
- `MealPlanResponse` expose `compliance_status` (`full` / `partial_budget` / `static_fallback`) et `compliance_warnings`, persistes dans `meal_plans` (V11).
- Router : `InfeasibleConstraintsError` -> HTTP 503 avec body plat `{detail, infeasible: true}` (via `JSONResponse`, sinon `HTTPException` aurait imbrique sous `detail`).
- `scripts/eval/llm_runner.py` : nouvelle passe `_run_pipeline_eval(n)` qui rejoue les memes inputs (meme seed) via `generate_plan(bypass_cache=True)`, compte les Ollama calls via un contextmanager qui swap `_ollama_generate`, mesure latence + retries + compliance_status + 503.
- `docs/metrics.json` : `llm.naive` (existant renomme) + `llm.pipeline` avec `by_constraint`, `retry_count_distribution`, `latency_p50/p95`. `docs/metrics.md` regenere avec la comparaison commentee.

## Test plan

- [x] 353 tests passent (`docker compose --profile test run --rm tests pytest -m "not slow"`), couverture 94%.
- [x] Nouveaux tests d'integration `tests/test_meal_plan_api.py` :
  - `test_response_includes_compliance_status_and_warnings_on_full`
  - `test_response_includes_static_fallback_when_ollama_down`
  - `test_infeasible_constraints_returns_503_with_explicit_body`
  - `test_compliance_persisted_to_meal_plans_table`
- [x] Tests unitaires `tests/unit/test_llm_client.py` mis a jour pour la nouvelle signature tuple.
- [x] Nouveaux helpers metriques (`compliance_status_breakdown`, `by_constraint_satisfaction`, `retry_count_distribution`) couverts dans `tests/unit/test_eval_llm_metrics.py`.
- [x] `ruff check` clean sur `app/`, `scripts/`, `tests/`.
- [ ] **A executer manuellement** : `python scripts/eval_metrics.py llm --n-generations 30 --n-constraint-plans 30` avec Ollama + PG accessibles pour peupler `docs/metrics.json` -> `llm.pipeline` avec des mesures reelles (le commit contient une structure placeholder + note explicative).