### PR TITLE
[Slice 10] Tests pytest + doc OpenAPI nettoyee + data_model.md finalise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,10 @@ jobs:
         with:
           name: coverage-html
           path: MSPR-AI-Nutrition/htmlcov/
+
+      - name: Upload coverage XML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: MSPR-AI-Nutrition/coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .venv*/
 .ruff_cache/
 .coverage
+coverage.xml
 htmlcov/
 .env

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Codes d'erreur retournes :
 - `429` : rate limit depasse (`/generate-meal-plan` : 10/h et 3/min).
 - `503` : Ollama et fallback statique tous indisponibles.
 
+### Snapshot OpenAPI versionne
+
+Le contrat est commit en JSON dans `docs/openapi.json` (livrable #6 MSPR2). Regenerer apres toute modification d'un router :
+
+```bash
+python scripts/export_openapi.py
+```
+
+Le test `tests/test_openapi_doc.py::test_openapi_snapshot_is_up_to_date` echoue tant que le fichier n'est pas synchronise avec le schema courant. Commiter le diff avec la PR qui modifie l'API.
+
 ## Tests
 
 Le harnais utilise pytest, testcontainers (PostgreSQL ephemere) et respx (mocks HTTP).

--- a/app/config.py
+++ b/app/config.py
@@ -31,7 +31,11 @@ class Settings(BaseSettings):
             f"@{self.db_host}:{self.db_port}/{self.db_name}"
         )
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 settings = Settings()

--- a/app/openapi_responses.py
+++ b/app/openapi_responses.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+# Reponses OpenAPI baseline imposees par l'AC de l'issue 56 (livrable #6 MSPR2).
+# Tous les endpoints metier (prefixe /api/v1/) doivent declarer ces codes en plus
+# de leurs reponses specifiques. Un code documente n'est pas necessairement
+# atteignable sur chaque endpoint : 403 ne se declenche qu'avec des entitlements
+# specifiques (tier premium par exemple), 503 uniquement sur les endpoints qui
+# appellent Ollama. La declaration sert d'enveloppe de contrat pour les clients.
+
+AC_BUSINESS_RESPONSES: dict[int, dict[str, str]] = {
+    400: {"description": "Requete malformee (body / parametre illisible)."},
+    401: {"description": "JWT manquant, malforme ou invalide."},
+    403: {
+        "description": (
+            "Permission insuffisante (entitlements ou tier requis pour cette "
+            "operation)."
+        )
+    },
+    422: {
+        "description": (
+            "Validation Pydantic en echec (type ou contrainte de champ violee)."
+        )
+    },
+    503: {
+        "description": (
+            "Service degrade : dependance externe (Ollama) injoignable et "
+            "fallback indisponible."
+        )
+    },
+}
+
+
+def with_ac_baseline(*specifics: dict) -> dict:
+    """Fusionne les reponses specifiques d'un endpoint avec la baseline AC.
+
+    Les entrees de `specifics` ecrasent la baseline pour un meme code (ex. un
+    endpoint qui veut une description 401 plus precise garde sa propre version).
+    Les nouveaux codes (404, 413, 415, 429) sont conserves tels quels.
+    """
+    merged: dict = dict(AC_BUSINESS_RESPONSES)
+    for spec in specifics:
+        merged.update(spec)
+    return merged

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.schemas import HealthGoal, MacroTargetsView, MeMacrosResponse
+from app.openapi_responses import with_ac_baseline
 from app.services import jwt_decoder, profile_service
 from app.services.nutrition_engine import (
     IncompleteProfile,
@@ -45,6 +46,32 @@ retourner une cible degradee.
 **Authentification** : header `Authorization: Bearer <jwt>` requis.
 """
 
+_MACROS_EXAMPLES = {
+    "complete_profile": {
+        "summary": "Profil complet : TDEE et macros calcules",
+        "value": {
+            "profile_completion_required": False,
+            "missing_fields": [],
+            "tdee": 2450,
+            "macros": {
+                "calories": 2450,
+                "protein_g": 184.0,
+                "carbs_g": 276.0,
+                "fat_g": 68.0,
+            },
+        },
+    },
+    "incomplete_profile": {
+        "summary": "Profil incomplet : champs manquants",
+        "value": {
+            "profile_completion_required": True,
+            "missing_fields": ["weight_kg", "height_cm"],
+            "tdee": None,
+            "macros": None,
+        },
+    },
+}
+
 
 @router.get(
     "/macros",
@@ -52,10 +79,14 @@ retourner une cible degradee.
     tags=["Profil"],
     summary="Cible journaliere TDEE et macros pour l'utilisateur",
     description=_DESCRIPTION,
-    responses={
-        200: {"description": "Cible journaliere ou liste des champs manquants."},
-        401: {"description": "JWT manquant, malforme ou invalide."},
-    },
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Cible journaliere ou liste des champs manquants.",
+                "content": {"application/json": {"examples": _MACROS_EXAMPLES}},
+            },
+        },
+    ),
 )
 def get_my_macros(
     authorization: str | None = Header(default=None),

--- a/app/routers/meal_analysis.py
+++ b/app/routers/meal_analysis.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.schemas import PaginatedAnalysesResponse
+from app.openapi_responses import with_ac_baseline
 from app.services import jwt_decoder, meal_analysis_history
 from app.services.meal_analysis_orchestrator import analyze_meal as orchestrate
 from app.services.nutrition_engine import MealType
@@ -133,16 +134,19 @@ _HISTORY_RESPONSE_EXAMPLE = {
     tags=["Analyse"],
     summary="Analyse une photo de repas (macros + recommandations IA)",
     description=_ANALYZE_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Analyse reussie : macros, desequilibres et recommandations.",
-            "content": {"application/json": {"example": _ANALYZE_SUCCESS_EXAMPLE}},
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Analyse reussie : macros, desequilibres et recommandations.",
+                "content": {"application/json": {"example": _ANALYZE_SUCCESS_EXAMPLE}},
+            },
+            413: {"description": "Image trop volumineuse (limite 10 Mo)."},
+            415: {
+                "description": "Type MIME non supporte (utiliser JPEG, PNG ou WebP)."
+            },
+            422: {"description": "Image illisible, corrompue ou aucun aliment detecte."},
         },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-        413: {"description": "Image trop volumineuse (limite 10 Mo)."},
-        415: {"description": "Type MIME non supporte (utiliser JPEG, PNG ou WebP)."},
-        422: {"description": "Image illisible, corrompue ou aucun aliment detecte."},
-    },
+    ),
 )
 async def analyze_meal(
     photo: UploadFile = File(
@@ -176,13 +180,14 @@ async def analyze_meal(
     tags=["Historique"],
     summary="Historique pagine des analyses de l'utilisateur",
     description=_HISTORY_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Liste pagine d'analyses (tri decroissant sur created_at).",
-            "content": {"application/json": {"example": _HISTORY_RESPONSE_EXAMPLE}},
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Liste pagine d'analyses (tri decroissant sur created_at).",
+                "content": {"application/json": {"example": _HISTORY_RESPONSE_EXAMPLE}},
+            },
         },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-    },
+    ),
 )
 def list_my_meal_analyses(
     authorization: str | None = Header(default=None),

--- a/app/routers/meal_plan.py
+++ b/app/routers/meal_plan.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.limiter import limiter
 from app.models.schemas import MealPlanRequest, MealPlanResponse, PaginatedPlansResponse
+from app.openapi_responses import with_ac_baseline
 from app.services import jwt_decoder, meal_plan_history, meal_plan_orchestrator
 from app.services.decrim_retry_orchestrator import InfeasibleConstraintsError
 
@@ -109,34 +110,35 @@ _PLAN_RESPONSE_EXAMPLE = {
     tags=["Plans"],
     summary="Genere un plan repas personnalise (1 a 30 jours)",
     description=_PLAN_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Plan repas genere ou recupere du cache. `fallback: true` indique un repli matrice statique.",
-            "content": {"application/json": {"example": _PLAN_RESPONSE_EXAMPLE}},
-        },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-        422: {
-            "description": "Payload invalide (regime inconnu, duree hors [1, 30], etc)."
-        },
-        429: {"description": "Rate limit depasse (10/heure ou 3/minute)."},
-        503: {
-            "description": (
-                "Contraintes infaisables (allergies / regime impossibles a satisfaire) "
-                "ou Ollama injoignable et fallback statique indisponible."
-            ),
-            "content": {
-                "application/json": {
-                    "example": {
-                        "detail": (
-                            "Contraintes infaisables, ajustez vos contraintes "
-                            "(allergies / regime)."
-                        ),
-                        "infeasible": True,
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Plan repas genere ou recupere du cache. `fallback: true` indique un repli matrice statique.",
+                "content": {"application/json": {"example": _PLAN_RESPONSE_EXAMPLE}},
+            },
+            422: {
+                "description": "Payload invalide (regime inconnu, duree hors [1, 30], etc)."
+            },
+            429: {"description": "Rate limit depasse (10/heure ou 3/minute)."},
+            503: {
+                "description": (
+                    "Contraintes infaisables (allergies / regime impossibles a satisfaire) "
+                    "ou Ollama injoignable et fallback statique indisponible."
+                ),
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "detail": (
+                                "Contraintes infaisables, ajustez vos contraintes "
+                                "(allergies / regime)."
+                            ),
+                            "infeasible": True,
+                        }
                     }
-                }
+                },
             },
         },
-    },
+    ),
 )
 @limiter.limit("10/hour;3/minute")
 async def generate_meal_plan(
@@ -227,15 +229,16 @@ _PLANS_HISTORY_RESPONSE_EXAMPLE = {
     tags=["Historique"],
     summary="Historique pagine des plans repas de l'utilisateur",
     description=_PLANS_HISTORY_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Liste pagine de plans repas (tri decroissant sur generated_at).",
-            "content": {
-                "application/json": {"example": _PLANS_HISTORY_RESPONSE_EXAMPLE}
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Liste pagine de plans repas (tri decroissant sur generated_at).",
+                "content": {
+                    "application/json": {"example": _PLANS_HISTORY_RESPONSE_EXAMPLE}
+                },
             },
         },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-    },
+    ),
 )
 def list_my_meal_plans(
     authorization: str | None = Header(default=None),

--- a/app/routers/nutrition_goals.py
+++ b/app/routers/nutrition_goals.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.schemas import NutritionGoalRequest, NutritionGoalResponse
+from app.openapi_responses import with_ac_baseline
 from app.services import jwt_decoder, profile_service
 
 router = APIRouter(prefix="/nutrition-goals")
@@ -89,16 +90,17 @@ _GOAL_REQUEST_EXAMPLES = {
     tags=["Profil"],
     summary="Recupere le profil nutritionnel de l'utilisateur",
     description=_GET_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Profil nutritionnel courant.",
-            "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Profil nutritionnel courant.",
+                "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+            },
+            404: {
+                "description": "Aucun profil nutritionnel configure (faire un PUT initial)."
+            },
         },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-        404: {
-            "description": "Aucun profil nutritionnel configure (faire un PUT initial)."
-        },
-    },
+    ),
 )
 def get_my_profile(
     authorization: str | None = Header(default=None),
@@ -119,16 +121,17 @@ def get_my_profile(
     tags=["Profil"],
     summary="Cree ou met a jour le profil nutritionnel (upsert)",
     description=_PUT_DESCRIPTION,
-    responses={
-        200: {
-            "description": "Profil mis a jour (ou cree).",
-            "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+    responses=with_ac_baseline(
+        {
+            200: {
+                "description": "Profil mis a jour (ou cree).",
+                "content": {"application/json": {"example": _GOAL_RESPONSE_EXAMPLE}},
+            },
+            422: {
+                "description": "Payload invalide (objectif sante inconnu, valeurs non numeriques, etc)."
+            },
         },
-        401: {"description": "JWT manquant, malforme ou invalide."},
-        422: {
-            "description": "Payload invalide (objectif sante inconnu, valeurs non numeriques, etc)."
-        },
-    },
+    ),
 )
 def upsert_my_profile(
     payload: NutritionGoalRequest = Body(..., openapi_examples=_GOAL_REQUEST_EXAMPLES),

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -112,7 +112,15 @@ Les 3 tables coexistent dans le schema `public` avec les tables ETL existantes (
 
 ### JSONB pour les structures variables
 
-`detected_foods`, `macros`, `plan`, `constraints` sont des structures dont le schema peut evoluer (ajout de nouveaux champs au gre des iterations LLM ou des extensions du modele). `JSONB` permet ces evolutions sans migration. Tradeoff connu : pas de validation SQL des sous-structures, c'est Pydantic cote application qui assure le contrat.
+`detected_foods`, `macros`, `plan`, `constraints`, ainsi que les champs V11 `imbalances` et `serving_sizes`, sont des structures dont le schema peut evoluer (ajout de nouveaux champs au gre des iterations LLM ou des extensions du modele). `JSONB` permet ces evolutions sans migration. Tradeoff connu : pas de validation SQL des sous-structures, c'est Pydantic cote application qui assure le contrat.
+
+### TEXT plutot qu'ENUM pour les statuts
+
+`meal_plans.compliance_status` (V11 : `full` / `partial_budget` / `static_fallback`) et `meal_analyses.meal_type` (V11 : `breakfast` / `lunch` / `dinner` / `snack`) sont declares en `TEXT` plutot qu'en `CREATE TYPE ... AS ENUM`. Trois raisons :
+
+- **Evolution sans `ALTER TYPE`** : ajouter une valeur a un ENUM PostgreSQL force une migration explicite avec `ALTER TYPE ... ADD VALUE`, non transactionnelle avant PG12 et toujours fastidieuse. TEXT permet d'introduire un nouveau statut (ex. `partial_diet`) sans toucher au schema.
+- **Validation cote application** : `app/services/decrim_retry_orchestrator.ComplianceStatus` et `app/services/nutrition_engine.MealType` sont des `enum.StrEnum` Pydantic. Le contrat est verifie a l'ecriture et a la lecture par Pydantic ; un INSERT direct en SQL avec une valeur libre passerait, mais aucun code applicatif ne le fait.
+- **Coherence avec les autres champs textuels enum-like** : `nutrition_goals.diet_type` (`VARCHAR(50)`) et `nutrition_goals.health_goal` (`VARCHAR(30)` + CHECK) suivent deja ce pattern. `health_goal` ajoute une contrainte CHECK ; ce n'est pas fait pour `compliance_status` / `meal_type` car le set de valeurs est destine a evoluer plus frequemment.
 
 ## Liens avec les endpoints
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1624 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MSPR HealthAI Coach - AI Nutrition",
+    "description": "\nMicro-service d'analyse nutritionnelle et de generation de plans repas par IA, partie de la plateforme MSPR HealthAI Coach.\n\nDeux pipelines d'IA sont exposes :\n\n- **Analyse de repas** : photo en entree, classification HuggingFace (`nateraw/food`, modele Food-101), lookup nutritionnel sur les datasets ETL, detection de desequilibres macros vs profil utilisateur, puis recommandations generees par Ollama (Gemma3:4b) avec fallback matrice statique.\n- **Generation de plans repas** : objectif de sante, preferences alimentaires et budget, prompt structure soumis a Ollama, validation du JSON et persistance du plan sur 1 a 30 jours.\n\nLe service expose egalement la gestion du profil nutritionnel (`nutrition-goals/me`) et l'historique pagine des analyses et des plans (`meal-analyses/me`, `meal-plans/me`). L'authentification se fait via JWT signe par MSPR-AUTH (`Authorization: Bearer <jwt>`).\n",
+    "contact": {
+      "name": "Arthur Poncin",
+      "email": "arthur.poncin@sixense-group.com"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Sante"
+        ],
+        "summary": "Healthcheck du service et de ses dependances",
+        "description": "Verifie l'etat operationnel du service et de ses dependances critiques.\n\nRenvoie un statut global, l'etat individuel de PostgreSQL et d'Ollama, ainsi qu'un horodatage UTC.\n\n- `status` : `ok` si toutes les dependances sont joignables, `degraded` sinon.\n- `postgres` : `up` ou `down` (timeout 3 s sur SELECT 1).\n- `ollama` : `up` ou `down` (timeout 3 s sur GET /api/tags).\n\nCet endpoint est non authentifie et ne consomme aucune ressource lourde. Il est utilise par les sondes de liveness/readiness Docker et par le monitoring.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Statut operationnel (ok ou degraded selon les dependances).",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "example": {
+                  "status": "ok",
+                  "postgres": "up",
+                  "ollama": "up",
+                  "timestamp": "2026-04-29T10:15:00.123456+00:00"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/analyze-meal": {
+      "post": {
+        "tags": [
+          "Analyse"
+        ],
+        "summary": "Analyse une photo de repas (macros + recommandations IA)",
+        "description": "Analyse une photo de repas et renvoie macros, desequilibres et recommandations.\n\nPipeline applique :\n\n1. Classification par le modele HuggingFace `nateraw/food` (Food-101, top-3 aliments + confiance).\n2. Lookup nutritionnel sur la table `nutrition_entries` (datasets ETL).\n3. Detection des desequilibres macros (calories, proteines, glucides, lipides) par rapport au profil utilisateur (`nutrition-goals/me`). Si aucun profil n'est configure, l'analyse renvoie quand meme les macros sans recommandations.\n4. Generation des recommandations par Ollama (Gemma3:4b) avec cache 30 jours par hash (top_label, health_goal, imbalances). En cas d'echec LLM, repli sur la matrice statique 16 cas (`fallback: true`).\n5. Persistance dans `meal_analyses` pour consultation via `GET /api/v1/meal-analyses/me`.\n\n**Limitations** : modele entraine sur Food-101 (101 classes occidentales), inference CPU (1-3 s par appel). Pour les recommandations, le LLM peut etre lent (5-15 s sur CPU), prevoir un timeout cote client.\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis (JWT signe par MSPR-AUTH).",
+        "operationId": "analyze_meal_api_v1_analyze_meal_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_analyze_meal_api_v1_analyze_meal_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Analyse reussie : macros, desequilibres et recommandations.",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "example": {
+                  "analysis_id": 137,
+                  "detected_foods": [
+                    {
+                      "label": "pizza",
+                      "confidence": 0.85,
+                      "nutrition": {
+                        "calories": 1300,
+                        "protein_g": 30,
+                        "carbs_g": 160,
+                        "fat_g": 50,
+                        "fiber_g": 5
+                      }
+                    },
+                    {
+                      "label": "lasagna",
+                      "confidence": 0.07
+                    }
+                  ],
+                  "macros": {
+                    "calories": 1300,
+                    "protein_g": 30,
+                    "carbs_g": 160,
+                    "fat_g": 50,
+                    "fiber_g": 5
+                  },
+                  "imbalances": [
+                    "Apport calorique eleve (65 % du daily target).",
+                    "Glucides au-dessus de la cible journaliere."
+                  ],
+                  "recommendations": [
+                    "Reduis la portion au prochain repas et privilegie une assiette plus protee.",
+                    "Equilibre la journee avec un diner riche en legumes verts."
+                  ],
+                  "fallback": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Image illisible, corrompue ou aucun aliment detecte."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          },
+          "413": {
+            "description": "Image trop volumineuse (limite 10 Mo)."
+          },
+          "415": {
+            "description": "Type MIME non supporte (utiliser JPEG, PNG ou WebP)."
+          }
+        }
+      }
+    },
+    "/api/v1/meal-analyses/me": {
+      "get": {
+        "tags": [
+          "Historique"
+        ],
+        "summary": "Historique pagine des analyses de l'utilisateur",
+        "description": "Renvoie l'historique pagine des analyses de repas pour l'utilisateur authentifie.\n\nTri decroissant par date d'analyse. Chaque element contient les aliments detectes, les macros, les recommandations sauvegardees et la date.\n\nPagination par `limit` (defaut 20, max 100) et `offset` (defaut 0). Le total est inclus dans la reponse pour permettre au client d'afficher un compteur ou de preparer une pagination infinie.\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis. L'historique est strictement scope a l'utilisateur du JWT.",
+        "operationId": "list_my_meal_analyses_api_v1_meal_analyses_me_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Liste pagine d'analyses (tri decroissant sur created_at).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAnalysesResponse"
+                },
+                "example": {
+                  "items": [
+                    {
+                      "id": 137,
+                      "detected_foods": [
+                        {
+                          "label": "pizza",
+                          "confidence": 0.85,
+                          "nutrition": {
+                            "calories": 1300,
+                            "protein_g": 30,
+                            "carbs_g": 160,
+                            "fat_g": 50
+                          }
+                        }
+                      ],
+                      "macros": {
+                        "calories": 1300,
+                        "protein_g": 30,
+                        "carbs_g": 160,
+                        "fat_g": 50,
+                        "fiber_g": 5
+                      },
+                      "recommendations": [
+                        "Reduis la portion au prochain repas."
+                      ],
+                      "created_at": "2026-04-29T10:15:00"
+                    }
+                  ],
+                  "total": 137,
+                  "limit": 20,
+                  "offset": 0
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Validation Pydantic en echec (type ou contrainte de champ violee)."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          }
+        }
+      }
+    },
+    "/api/v1/generate-meal-plan": {
+      "post": {
+        "tags": [
+          "Plans"
+        ],
+        "summary": "Genere un plan repas personnalise (1 a 30 jours)",
+        "description": "Genere un plan repas personnalise sur 1 a 30 jours en fonction de l'objectif sante, du regime, des allergies et du budget.\n\nPipeline applique :\n\n1. Resolution de l'objectif sante : valeur explicite > profil utilisateur (`nutrition-goals/me`) > `balance` par defaut.\n2. Lecture des entitlements (tier utilisateur via MSPR-AUTH). Les tiers `premium` et `premium_plus` bypassent le cache et regenerent systematiquement.\n3. Cache contenu : hash canonique des inputs (objectif, regime, allergies triees, budget, calories cible, duree). Cache hit, on renvoie le plan stocke.\n4. Cache miss : appel Ollama (Gemma3:4b) avec prompt structure et `format: json`. En cas d'echec ou JSON invalide, repli sur la matrice 16 plans statiques (`fallback: true`).\n5. Persistance dans `meal_plans` et renvoi du plan complet.\n\n**Rate limit** : 10 requetes par heure et 3 par minute par utilisateur (header standard `Retry-After` en cas de depassement).\n\n**Latence** : 5-30 s sur CPU pour une generation LLM. Cache hit < 100 ms.\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis. Le JWT est aussi propage a MSPR-AUTH pour resoudre les entitlements.",
+        "operationId": "generate_meal_plan_api_v1_generate_meal_plan_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MealPlanRequest"
+              },
+              "examples": {
+                "muscle_gain_omnivore": {
+                  "summary": "Prise de masse, omnivore, 7 jours",
+                  "value": {
+                    "health_goal": "muscle_gain",
+                    "diet_type": "omnivore",
+                    "duration_days": 7,
+                    "allergies": [],
+                    "budget_eur_per_day": 15.0
+                  }
+                },
+                "weight_loss_vegetarien": {
+                  "summary": "Perte de poids, vegetarien, 14 jours",
+                  "value": {
+                    "health_goal": "weight_loss",
+                    "diet_type": "vegetarien",
+                    "duration_days": 14,
+                    "allergies": [
+                      "arachides"
+                    ],
+                    "budget_eur_per_day": 10.0
+                  }
+                },
+                "balance_vegan_minimum": {
+                  "summary": "Equilibre, vegan, requete minimale (1 jour, sans budget)",
+                  "value": {
+                    "diet_type": "vegan",
+                    "duration_days": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Plan repas genere ou recupere du cache. `fallback: true` indique un repli matrice statique.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MealPlanResponse"
+                },
+                "example": {
+                  "plan_id": 42,
+                  "fallback": false,
+                  "days": [
+                    {
+                      "day": 1,
+                      "meals": [
+                        {
+                          "name": "Bowl quinoa, poulet et legumes verts",
+                          "macros": {
+                            "calories": 620,
+                            "protein_g": 45.0,
+                            "carbs_g": 65.0,
+                            "fat_g": 18.0
+                          },
+                          "ingredients": [
+                            "100 g quinoa",
+                            "150 g blanc de poulet",
+                            "200 g brocolis",
+                            "1 c.s. huile d'olive"
+                          ],
+                          "est_budget_eur": 5.5,
+                          "prep_time_min": 25
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Payload invalide (regime inconnu, duree hors [1, 30], etc)."
+          },
+          "503": {
+            "description": "Contraintes infaisables (allergies / regime impossibles a satisfaire) ou Ollama injoignable et fallback statique indisponible.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": "Contraintes infaisables, ajustez vos contraintes (allergies / regime).",
+                  "infeasible": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit depasse (10/heure ou 3/minute)."
+          }
+        }
+      }
+    },
+    "/api/v1/meal-plans/me": {
+      "get": {
+        "tags": [
+          "Historique"
+        ],
+        "summary": "Historique pagine des plans repas de l'utilisateur",
+        "description": "Renvoie l'historique pagine des plans repas generes pour l'utilisateur authentifie.\n\nTri decroissant par date de generation. Chaque element contient l'objectif sante, les contraintes (regime, allergies, budget, duree, calories cible) et le plan complet (jours et repas).\n\nPagination par `limit` (defaut 20, max 100) et `offset` (defaut 0). Le total est inclus dans la reponse pour permettre au client d'afficher un compteur ou de preparer une pagination infinie.\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis. L'historique est strictement scope a l'utilisateur du JWT.",
+        "operationId": "list_my_meal_plans_api_v1_meal_plans_me_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Liste pagine de plans repas (tri decroissant sur generated_at).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedPlansResponse"
+                },
+                "example": {
+                  "items": [
+                    {
+                      "id": 42,
+                      "objective": "muscle_gain",
+                      "constraints": {
+                        "diet_type": "omnivore",
+                        "allergies": [
+                          "arachides"
+                        ],
+                        "duration_days": 7,
+                        "budget_per_day": 15.0
+                      },
+                      "plan": {
+                        "fallback": false,
+                        "days": [
+                          {
+                            "day": 1,
+                            "meals": [
+                              {
+                                "name": "Bowl quinoa, poulet et legumes verts",
+                                "macros": {
+                                  "calories": 620,
+                                  "protein_g": 45.0,
+                                  "carbs_g": 65.0,
+                                  "fat_g": 18.0
+                                },
+                                "ingredients": [
+                                  "100 g quinoa",
+                                  "150 g blanc de poulet"
+                                ],
+                                "est_budget_eur": 5.5,
+                                "prep_time_min": 25
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "generated_at": "2026-04-29T10:15:00"
+                    }
+                  ],
+                  "total": 12,
+                  "limit": 20,
+                  "offset": 0
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Validation Pydantic en echec (type ou contrainte de champ violee)."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          }
+        }
+      }
+    },
+    "/api/v1/nutrition-goals/me": {
+      "get": {
+        "tags": [
+          "Profil"
+        ],
+        "summary": "Recupere le profil nutritionnel de l'utilisateur",
+        "description": "Renvoie le profil nutritionnel de l'utilisateur authentifie.\n\nLe profil regroupe l'objectif sante (`weight_loss`, `muscle_gain`, `balance`, `sport_performance`), les cibles caloriques et macros, les allergies declarees et le regime (`omnivore`, `vegetarien`, `vegan`, `sans_gluten`).\n\nRenvoie 404 si aucun profil n'a encore ete configure (un PUT initial est alors necessaire).\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis. Le profil est strictement scope a l'utilisateur du JWT.",
+        "operationId": "get_my_profile_api_v1_nutrition_goals_me_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Profil nutritionnel courant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NutritionGoalResponse"
+                },
+                "example": {
+                  "user_id": 42,
+                  "health_goal": "muscle_gain",
+                  "calories_target": 2400,
+                  "protein_g": "140.0",
+                  "carbs_g": "260.0",
+                  "fat_g": "80.0",
+                  "allergies": [
+                    "arachides",
+                    "fruits a coque"
+                  ],
+                  "diet_type": "omnivore"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Validation Pydantic en echec (type ou contrainte de champ violee)."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          },
+          "404": {
+            "description": "Aucun profil nutritionnel configure (faire un PUT initial)."
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Profil"
+        ],
+        "summary": "Cree ou met a jour le profil nutritionnel (upsert)",
+        "description": "Cree ou met a jour le profil nutritionnel de l'utilisateur authentifie (upsert).\n\nTous les champs sont optionnels : un PUT partiel ecrase la ligne avec la valeur fournie. Pour conserver une valeur existante, le client doit la renvoyer explicitement.\n\nLes valeurs sont utilisees ensuite par `/analyze-meal` (detection des desequilibres) et `/generate-meal-plan` (resolution de l'objectif sante par defaut).\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis.",
+        "operationId": "upsert_my_profile_api_v1_nutrition_goals_me_put",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NutritionGoalRequest"
+              },
+              "examples": {
+                "muscle_gain": {
+                  "summary": "Prise de masse, omnivore",
+                  "value": {
+                    "health_goal": "muscle_gain",
+                    "calories_target": 2400,
+                    "protein_g": 140,
+                    "carbs_g": 260,
+                    "fat_g": 80,
+                    "allergies": [
+                      "arachides"
+                    ],
+                    "diet_type": "omnivore"
+                  }
+                },
+                "weight_loss_vegetarien": {
+                  "summary": "Perte de poids, vegetarien",
+                  "value": {
+                    "health_goal": "weight_loss",
+                    "calories_target": 1700,
+                    "protein_g": 90,
+                    "carbs_g": 170,
+                    "fat_g": 55,
+                    "allergies": [],
+                    "diet_type": "vegetarien"
+                  }
+                },
+                "minimal": {
+                  "summary": "Profil minimal (objectif sante seul)",
+                  "value": {
+                    "health_goal": "balance"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Profil mis a jour (ou cree).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NutritionGoalResponse"
+                },
+                "example": {
+                  "user_id": 42,
+                  "health_goal": "muscle_gain",
+                  "calories_target": 2400,
+                  "protein_g": "140.0",
+                  "carbs_g": "260.0",
+                  "fat_g": "80.0",
+                  "allergies": [
+                    "arachides",
+                    "fruits a coque"
+                  ],
+                  "diet_type": "omnivore"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Payload invalide (objectif sante inconnu, valeurs non numeriques, etc)."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          }
+        }
+      }
+    },
+    "/api/v1/me/macros": {
+      "get": {
+        "tags": [
+          "Profil"
+        ],
+        "summary": "Cible journaliere TDEE et macros pour l'utilisateur",
+        "description": "Retourne la cible journaliere de l'utilisateur authentifie (TDEE et macros).\n\nLe TDEE est calcule via la formule de Mifflin-St Jeor a partir des champs\nbiometriques du profil (`gender`, `age`, `weight_kg`, `height_cm`, `activity_level`)\net de l'objectif sante (`health_goal`). La repartition macro suit l'objectif :\n\n- `balance` : 50 % glucides, 20 % proteines, 30 % lipides\n- `weight_loss` : 40 / 30 / 30\n- `muscle_gain` : 45 / 30 / 25\n- `sport_performance` : 55 / 20 / 25\n\nQuand un champ biometrique est manquant, la reponse renseigne\n`profile_completion_required=true` et liste les `missing_fields` plutot que de\nretourner une cible degradee.\n\n**Authentification** : header `Authorization: Bearer <jwt>` requis.",
+        "operationId": "get_my_macros_api_v1_me_macros_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cible journaliere ou liste des champs manquants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeMacrosResponse"
+                },
+                "examples": {
+                  "complete_profile": {
+                    "summary": "Profil complet : TDEE et macros calcules",
+                    "value": {
+                      "profile_completion_required": false,
+                      "missing_fields": [],
+                      "tdee": 2450,
+                      "macros": {
+                        "calories": 2450,
+                        "protein_g": 184.0,
+                        "carbs_g": 276.0,
+                        "fat_g": 68.0
+                      }
+                    }
+                  },
+                  "incomplete_profile": {
+                    "summary": "Profil incomplet : champs manquants",
+                    "value": {
+                      "profile_completion_required": true,
+                      "missing_fields": [
+                        "weight_kg",
+                        "height_cm"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Requete malformee (body / parametre illisible)."
+          },
+          "401": {
+            "description": "JWT manquant, malforme ou invalide."
+          },
+          "403": {
+            "description": "Permission insuffisante (entitlements ou tier requis pour cette operation)."
+          },
+          "422": {
+            "description": "Validation Pydantic en echec (type ou contrainte de champ violee)."
+          },
+          "503": {
+            "description": "Service degrade : dependance externe (Ollama) injoignable et fallback indisponible."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActivityLevel": {
+        "type": "string",
+        "enum": [
+          "sedentary",
+          "light",
+          "moderate",
+          "active",
+          "very_active"
+        ],
+        "title": "ActivityLevel"
+      },
+      "Body_analyze_meal_api_v1_analyze_meal_post": {
+        "properties": {
+          "photo": {
+            "type": "string",
+            "format": "binary",
+            "title": "Photo",
+            "description": "Photo du repas (JPEG, PNG ou WebP, 10 Mo max)."
+          },
+          "meal_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MealType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "breakfast / lunch / dinner / snack. Defaut : fallback TDEE/4."
+          }
+        },
+        "type": "object",
+        "required": [
+          "photo"
+        ],
+        "title": "Body_analyze_meal_api_v1_analyze_meal_post"
+      },
+      "DietType": {
+        "type": "string",
+        "enum": [
+          "omnivore",
+          "vegetarien",
+          "vegan",
+          "sans_gluten"
+        ],
+        "title": "DietType"
+      },
+      "Gender": {
+        "type": "string",
+        "enum": [
+          "male",
+          "female"
+        ],
+        "title": "Gender"
+      },
+      "HealthGoal": {
+        "type": "string",
+        "enum": [
+          "weight_loss",
+          "muscle_gain",
+          "balance",
+          "sport_performance"
+        ],
+        "title": "HealthGoal"
+      },
+      "MacroTargetsView": {
+        "properties": {
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "protein_g": {
+            "type": "number",
+            "title": "Protein G"
+          },
+          "carbs_g": {
+            "type": "number",
+            "title": "Carbs G"
+          },
+          "fat_g": {
+            "type": "number",
+            "title": "Fat G"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "protein_g",
+          "carbs_g",
+          "fat_g"
+        ],
+        "title": "MacroTargetsView"
+      },
+      "MeMacrosResponse": {
+        "properties": {
+          "profile_completion_required": {
+            "type": "boolean",
+            "title": "Profile Completion Required"
+          },
+          "missing_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Fields",
+            "default": []
+          },
+          "tdee": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tdee"
+          },
+          "macros": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MacroTargetsView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "profile_completion_required"
+        ],
+        "title": "MeMacrosResponse"
+      },
+      "Meal": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "macros": {
+            "$ref": "#/components/schemas/MealMacros"
+          },
+          "ingredients": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "est_budget_eur": {
+            "type": "number",
+            "title": "Est Budget Eur"
+          },
+          "prep_time_min": {
+            "type": "integer",
+            "title": "Prep Time Min"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "macros",
+          "ingredients",
+          "est_budget_eur",
+          "prep_time_min"
+        ],
+        "title": "Meal"
+      },
+      "MealAnalysisItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "detected_foods": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Detected Foods"
+          },
+          "macros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Macros"
+          },
+          "recommendations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Recommendations"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "detected_foods",
+          "macros",
+          "recommendations",
+          "created_at"
+        ],
+        "title": "MealAnalysisItem"
+      },
+      "MealDay": {
+        "properties": {
+          "day": {
+            "type": "integer",
+            "title": "Day"
+          },
+          "meals": {
+            "items": {
+              "$ref": "#/components/schemas/Meal"
+            },
+            "type": "array",
+            "title": "Meals"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "meals"
+        ],
+        "title": "MealDay"
+      },
+      "MealMacros": {
+        "properties": {
+          "calories": {
+            "type": "integer",
+            "title": "Calories"
+          },
+          "protein_g": {
+            "type": "number",
+            "title": "Protein G"
+          },
+          "carbs_g": {
+            "type": "number",
+            "title": "Carbs G"
+          },
+          "fat_g": {
+            "type": "number",
+            "title": "Fat G"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "protein_g",
+          "carbs_g",
+          "fat_g"
+        ],
+        "title": "MealMacros"
+      },
+      "MealPlanHistoryItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "objective": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Objective"
+          },
+          "constraints": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Constraints"
+          },
+          "plan": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Plan"
+          },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "objective",
+          "constraints",
+          "plan",
+          "generated_at"
+        ],
+        "title": "MealPlanHistoryItem"
+      },
+      "MealPlanRequest": {
+        "properties": {
+          "health_goal": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HealthGoal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "allergies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allergies",
+            "default": []
+          },
+          "budget_eur_per_day": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Eur Per Day"
+          },
+          "diet_type": {
+            "$ref": "#/components/schemas/DietType"
+          },
+          "duration_days": {
+            "type": "integer",
+            "maximum": 30.0,
+            "minimum": 1.0,
+            "title": "Duration Days",
+            "default": 7
+          }
+        },
+        "type": "object",
+        "required": [
+          "diet_type"
+        ],
+        "title": "MealPlanRequest"
+      },
+      "MealPlanResponse": {
+        "properties": {
+          "plan_id": {
+            "type": "integer",
+            "title": "Plan Id"
+          },
+          "fallback": {
+            "type": "boolean",
+            "title": "Fallback"
+          },
+          "days": {
+            "items": {
+              "$ref": "#/components/schemas/MealDay"
+            },
+            "type": "array",
+            "title": "Days"
+          },
+          "compliance_status": {
+            "type": "string",
+            "enum": [
+              "full",
+              "partial_budget",
+              "static_fallback"
+            ],
+            "title": "Compliance Status",
+            "default": "full"
+          },
+          "compliance_warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Compliance Warnings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "plan_id",
+          "fallback",
+          "days"
+        ],
+        "title": "MealPlanResponse"
+      },
+      "MealType": {
+        "type": "string",
+        "enum": [
+          "breakfast",
+          "lunch",
+          "dinner",
+          "snack"
+        ],
+        "title": "MealType"
+      },
+      "NutritionGoalRequest": {
+        "properties": {
+          "health_goal": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HealthGoal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calories_target": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Calories Target"
+          },
+          "protein_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein G"
+          },
+          "carbs_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Carbs G"
+          },
+          "fat_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fat G"
+          },
+          "allergies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allergies",
+            "default": []
+          },
+          "diet_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diet Type"
+          },
+          "gender": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Gender"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "weight_kg": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight Kg"
+          },
+          "height_cm": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height Cm"
+          },
+          "activity_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ActivityLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "NutritionGoalRequest"
+      },
+      "NutritionGoalResponse": {
+        "properties": {
+          "health_goal": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HealthGoal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calories_target": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Calories Target"
+          },
+          "protein_g": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein G"
+          },
+          "carbs_g": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Carbs G"
+          },
+          "fat_g": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fat G"
+          },
+          "allergies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allergies",
+            "default": []
+          },
+          "diet_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diet Type"
+          },
+          "gender": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Gender"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "weight_kg": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight Kg"
+          },
+          "height_cm": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height Cm"
+          },
+          "activity_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ActivityLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id"
+        ],
+        "title": "NutritionGoalResponse"
+      },
+      "PaginatedAnalysesResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MealAnalysisItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "PaginatedAnalysesResponse",
+        "example": {
+          "items": [
+            {
+              "created_at": "2026-04-29T10:15:00",
+              "detected_foods": [
+                {
+                  "confidence": 0.85,
+                  "label": "pizza",
+                  "nutrition": {}
+                }
+              ],
+              "id": 42,
+              "macros": {
+                "calories": 1300,
+                "carbs_g": 160,
+                "fat_g": 50,
+                "protein_g": 30
+              },
+              "recommendations": [
+                "Reduis la portion au prochain repas."
+              ]
+            }
+          ],
+          "limit": 20,
+          "offset": 0,
+          "total": 137
+        }
+      },
+      "PaginatedPlansResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MealPlanHistoryItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "PaginatedPlansResponse",
+        "example": {
+          "items": [
+            {
+              "constraints": {
+                "allergies": [],
+                "diet_type": "vegan",
+                "duration_days": 7
+              },
+              "generated_at": "2026-04-29T10:15:00",
+              "id": 42,
+              "objective": "weight_loss",
+              "plan": {
+                "days": [
+                  {
+                    "day": 1,
+                    "meals": []
+                  }
+                ]
+              }
+            }
+          ],
+          "limit": 20,
+          "offset": 0,
+          "total": 17
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Analyse",
+      "description": "Analyse d'un repas a partir d'une photo : classification HuggingFace, macros et recommandations."
+    },
+    {
+      "name": "Plans",
+      "description": "Generation de plans repas personnalises via Ollama (avec fallback matrice statique)."
+    },
+    {
+      "name": "Profil",
+      "description": "Gestion du profil nutritionnel de l'utilisateur (objectifs caloriques, macros cibles, allergies, regime)."
+    },
+    {
+      "name": "Historique",
+      "description": "Lecture pagine des analyses de repas et des plans generes pour l'utilisateur authentifie."
+    },
+    {
+      "name": "Sante",
+      "description": "Healthcheck du service et de ses dependances (PostgreSQL, Ollama)."
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ addopts = [
     "--cov=app",
     "--cov-report=term-missing",
     "--cov-report=html",
+    "--cov-report=xml",
 ]
 
 [tool.coverage.run]

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,36 @@
+"""Dump le schema OpenAPI courant dans `docs/openapi.json`.
+
+Livrable #6 MSPR2 : snapshot versionne du contrat API. Le test
+`tests/test_openapi_doc.py::test_openapi_snapshot_is_up_to_date` echoue tant que
+ce fichier n'est pas regenere apres une modification du code des routers.
+
+Usage :
+    python scripts/export_openapi.py
+
+Le fichier est ecrit en JSON UTF-8 indente 2 espaces, sans ASCII escaping
+(pour preserver les accents francais des descriptions).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.main import app
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = REPO_ROOT / "docs" / "openapi.json"
+
+
+def main() -> None:
+    schema = app.openapi()
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(
+        json.dumps(schema, ensure_ascii=False, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Schema OpenAPI ecrit dans {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openapi_doc.py
+++ b/tests/test_openapi_doc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -7,17 +9,42 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENAPI_SNAPSHOT_PATH = REPO_ROOT / "docs" / "openapi.json"
+
 VALID_TAGS = {"Analyse", "Plans", "Profil", "Historique", "Sante"}
 
-# (path, method, expected_tag, expected_error_codes)
-EXPECTED_OPERATIONS: list[tuple[str, str, str, set[str]]] = [
+# AC issue 56 : tous les endpoints metier (prefixe /api/v1/) exposent au moins
+# {200, 400, 401, 403, 422, 503} dans leur documentation OpenAPI.
+# Ces codes peuvent ne pas etre tous reachables (ex. 403 sans entitlements
+# specifique), ils sont documentes pour annoncer aux clients l'eventail des
+# reponses possibles cote service.
+AC_BUSINESS_ERROR_CODES = {"400", "401", "403", "422", "503"}
+
+# Codes specifiques en sus du baseline AC, par operation. /health est hors AC
+# (endpoint sante unauth, ne touche pas Ollama, renvoie 200 avec status).
+EXTRA_ERROR_CODES: list[tuple[str, str, str, set[str]]] = [
     ("/health", "get", "Sante", set()),
-    ("/api/v1/analyze-meal", "post", "Analyse", {"401", "413", "415", "422"}),
-    ("/api/v1/meal-analyses/me", "get", "Historique", {"401"}),
-    ("/api/v1/meal-plans/me", "get", "Historique", {"401"}),
-    ("/api/v1/generate-meal-plan", "post", "Plans", {"401", "422", "429"}),
-    ("/api/v1/nutrition-goals/me", "get", "Profil", {"401", "404"}),
-    ("/api/v1/nutrition-goals/me", "put", "Profil", {"401", "422"}),
+    ("/api/v1/analyze-meal", "post", "Analyse", {"413", "415"}),
+    ("/api/v1/meal-analyses/me", "get", "Historique", set()),
+    ("/api/v1/meal-plans/me", "get", "Historique", set()),
+    ("/api/v1/generate-meal-plan", "post", "Plans", {"429"}),
+    ("/api/v1/nutrition-goals/me", "get", "Profil", {"404"}),
+    ("/api/v1/nutrition-goals/me", "put", "Profil", set()),
+    ("/api/v1/me/macros", "get", "Profil", set()),
+]
+
+
+def _expected_error_codes(path: str, extra: set[str]) -> set[str]:
+    """AC baseline pour les endpoints metier, vide pour /health."""
+    if path.startswith("/api/v1/"):
+        return AC_BUSINESS_ERROR_CODES | extra
+    return extra
+
+
+EXPECTED_OPERATIONS: list[tuple[str, str, str, set[str]]] = [
+    (path, method, tag, _expected_error_codes(path, extra))
+    for path, method, tag, extra in EXTRA_ERROR_CODES
 ]
 
 
@@ -95,3 +122,74 @@ def test_operation_is_richly_documented(
     assert (
         not missing_errors
     ), f"{method.upper()} {path} : codes d'erreur manquants {missing_errors}"
+
+
+# AC issue 56 : chaque endpoint metier doit fournir un exemple de reponse 200
+# pour faciliter la decouverte API depuis Swagger / Redoc.
+ENDPOINTS_WITH_RESPONSE_EXAMPLE: list[tuple[str, str]] = [
+    ("/api/v1/analyze-meal", "post"),
+    ("/api/v1/meal-analyses/me", "get"),
+    ("/api/v1/meal-plans/me", "get"),
+    ("/api/v1/generate-meal-plan", "post"),
+    ("/api/v1/nutrition-goals/me", "get"),
+    ("/api/v1/nutrition-goals/me", "put"),
+    ("/api/v1/me/macros", "get"),
+]
+
+
+@pytest.mark.parametrize(
+    "path,method",
+    ENDPOINTS_WITH_RESPONSE_EXAMPLE,
+    ids=[f"{m.upper()} {p}" for p, m in ENDPOINTS_WITH_RESPONSE_EXAMPLE],
+)
+def test_endpoint_has_200_example(
+    openapi_schema: dict[str, Any], path: str, method: str
+) -> None:
+    op = openapi_schema["paths"][path][method]
+    success = op["responses"].get("200") or {}
+    content = (success.get("content") or {}).get("application/json") or {}
+    assert (
+        content.get("example") or content.get("examples")
+    ), f"{method.upper()} {path} : pas d'example dans la reponse 200"
+
+
+# AC issue 56 : les endpoints qui acceptent un body doivent fournir au moins un
+# exemple de requete (Swagger l'affiche dans le "Try it out").
+ENDPOINTS_WITH_REQUEST_EXAMPLE: list[tuple[str, str, str]] = [
+    ("/api/v1/generate-meal-plan", "post", "application/json"),
+    ("/api/v1/nutrition-goals/me", "put", "application/json"),
+]
+
+
+@pytest.mark.parametrize(
+    "path,method,media_type",
+    ENDPOINTS_WITH_REQUEST_EXAMPLE,
+    ids=[f"{m.upper()} {p}" for p, m, _ in ENDPOINTS_WITH_REQUEST_EXAMPLE],
+)
+def test_endpoint_has_request_example(
+    openapi_schema: dict[str, Any], path: str, method: str, media_type: str
+) -> None:
+    op = openapi_schema["paths"][path][method]
+    request_body = op.get("requestBody") or {}
+    content = (request_body.get("content") or {}).get(media_type) or {}
+    assert (
+        content.get("example") or content.get("examples")
+    ), f"{method.upper()} {path} : pas d'example dans le requestBody {media_type}"
+
+
+def test_openapi_snapshot_is_up_to_date(openapi_schema: dict[str, Any]) -> None:
+    """Le snapshot `docs/openapi.json` doit refleter le schema courant.
+
+    Drift detection : si le schema FastAPI change (nouveau endpoint, code
+    d'erreur, example...), regenerer via `python scripts/export_openapi.py`
+    et committer le diff.
+    """
+    assert OPENAPI_SNAPSHOT_PATH.exists(), (
+        f"snapshot OpenAPI manquant : {OPENAPI_SNAPSHOT_PATH} "
+        "(regenerer avec `python scripts/export_openapi.py`)"
+    )
+    snapshot = json.loads(OPENAPI_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    assert snapshot == openapi_schema, (
+        "snapshot OpenAPI obsolete : regenerer avec "
+        "`python scripts/export_openapi.py` et committer le diff."
+    )


### PR DESCRIPTION
## Summary

Slice final du PRD #45 : durcissement tests/coverage, nettoyage OpenAPI et finalisation data_model.md pour V11.

- Coverage 94 % global, modules AC (nutrition_engine, constraint_validator, portion_sizes, decrim_retry_orchestrator, imbalance_detector) entre 93 et 100 %.
- Baseline OpenAPI 400/401/403/422/503 sur tous les endpoints metier, examples request/response, snapshot `docs/openapi.json` versionne avec drift detection.
- Justification TEXT vs ENUM ajoutee dans data_model.md.

## Test plan

- [x] `pytest -m "not slow"` : 375 passed (en local via Docker).
- [x] `ruff check .` : clean.
- [x] `pytest --cov=app --cov-report=xml --cov-report=term` produit `coverage.xml`.
- [x] `python scripts/export_openapi.py` regenere `docs/openapi.json` (test `test_openapi_snapshot_is_up_to_date` echoue si le snapshot est obsolete).
- [ ] CI verte sur la branche apres push.

Closes #56